### PR TITLE
Add API key creation guidance to budget guard plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ openclaw plugins enable cycles-openclaw-budget-guard
 
 That's it — the plugin uses sensible defaults for everything else. The agent will now enforce budget limits on every run.
 
+> **Need an API key?** API keys are created via the Cycles Admin Server (port 7979). See the [deployment guide](https://runcycles.io/quickstart/deploying-the-full-cycles-stack#step-3-create-an-api-key) to create one, or see [API Key Management](https://runcycles.io/how-to/api-key-management-in-cycles) for details.
+
 ### 4. (Optional) Use environment variables for secrets
 
 ```bash


### PR DESCRIPTION
## Summary
Added clarification to the README documentation for the budget guard plugin to help users understand how to obtain API keys, which are required for the plugin to function.

## Changes
- Added a note block in the budget guard plugin setup section directing users to the Cycles Admin Server (port 7979) for API key creation
- Included links to relevant documentation:
  - Deployment guide for initial API key creation
  - API Key Management guide for additional details

## Details
This documentation enhancement addresses a potential gap in the setup instructions where users might not know where or how to create the necessary API keys. The note is positioned immediately after the basic plugin enablement command, making it visible to users following the quick start guide.

https://claude.ai/code/session_01HftF1nebzvUzQy4y4zGJk6