### PR TITLE
Add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # cycles-openclaw-budget-guard
 
+[![CI](https://github.com/runcycles/cycles-openclaw-budget-guard/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/runcycles/cycles-openclaw-budget-guard/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@runcycles/openclaw-budget-guard)](https://www.npmjs.com/package/@runcycles/openclaw-budget-guard)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE)
+[![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
+
 OpenClaw plugin for budget-aware model and tool execution using [Cycles](https://github.com/runcycles).
 
 ## Overview


### PR DESCRIPTION
## Summary
Added status badges to the README to provide quick visibility into the project's CI/CD status, package availability, and technical requirements.

## Changes
- Added CI workflow badge linking to GitHub Actions
- Added npm package version badge
- Added Apache 2.0 license badge
- Added Node.js version requirement badge (>=20)
- Added TypeScript strict mode badge

These badges are now displayed prominently at the top of the README, giving users and contributors immediate insight into the project's health, availability, and technical specifications.

https://claude.ai/code/session_01KeTjjjiHBWULed5DQpJQc7