### PR TITLE
chore: bump version to 0.3.0 for protocol v0.1.24

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "cycles-openclaw-budget-guard",
   "name": "Cycles OpenClaw Budget Guard",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenClaw plugin for budget-aware model and tool execution using Cycles.",
   "extensions": ["./dist/index.js"],
   "configSchema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@runcycles/openclaw-budget-guard",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@runcycles/openclaw-budget-guard",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "runcycles": "^0.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runcycles/openclaw-budget-guard",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenClaw plugin for budget-aware model and tool execution using Cycles.",
   "license": "Apache-2.0",
   "author": "runcycles",


### PR DESCRIPTION
## Summary
- Bump version from 0.2.0 to 0.3.0 to reflect protocol spec v0.1.24 changes (new error codes, `charged` field on EventCreateResponse)
## Files changed
- `package.json` — version bump
- `package-lock.json` — regenerated
- `openclaw.plugin.json` — plugin manifest version
 
https://claude.ai/code/session_015Gqqb6uHu7M6KgjhSMX8qo