### PR TITLE
Add Claude settings and git workflow guidelines

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git pull:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ],
+    "deny": [
+      "mcp__github__create_or_update_file",
+      "mcp__github__push_files",
+      "mcp__github__create_or_update_files",
+      "mcp__github__delete_file"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+## Git Rules — STRICT
+- ALWAYS use native git for ALL commits and pushes
+- NEVER use mcp__github__ tools for committing or pushing
+- Use mcp__github__ ONLY for: PRs, Issues, GitHub Actions
+- Write commit messages to a temp file, then: `git commit -F <file>`
+- NEVER use --no-gpg-sign flag
+
+# Cycles strict rules
+- yaml API specs always the authority
+- always udated AUDIT.md files when making changes to server, admin, client repos
+- maintain at least 95% or higher test coverage for all code repos


### PR DESCRIPTION
## Summary
This PR establishes configuration and documentation for Claude-assisted development workflows, with a focus on enforcing native git operations and maintaining code quality standards.

## Key Changes
- **`.claude/settings.json`**: Added configuration file that:
  - Defines permission allowlist for git operations (add, commit, push, pull, status, diff, log)
  - Denies access to GitHub MCP tools for file operations (create, update, delete, push)
  - Reserves GitHub MCP tools for PR, issue, and Actions management only
  - Includes placeholder fields for attribution tracking

- **`CLAUDE.md`**: Added development guidelines documenting:
  - Strict requirement to use native git for all commits and pushes
  - Prohibition on using mcp__github__ tools for version control operations
  - Recommended workflow for commit messages (write to temp file, use `git commit -F`)
  - Code quality standards (95%+ test coverage requirement)
  - Requirement to maintain AUDIT.md files across server, admin, and client repositories
  - YAML API specs as the source of truth for API definitions

## Implementation Details
These files establish guardrails for AI-assisted development by:
1. Preventing accidental use of GitHub API tools for git operations
2. Ensuring all commits use proper git tooling with GPG signing support
3. Maintaining audit trails and documentation standards across the codebase
4. Enforcing consistent test coverage and specification-driven development

https://claude.ai/code/session_01KTnp1Sj8UL3pt7K56q9SjV