### PR TITLE
fix: align plugin manifest id with npm-derived id

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -60,7 +60,7 @@ The 3 remaining uncovered branches are unreachable by design: `ctx.metadata` is 
 | Requirement | Location | Status |
 |---|---|---|
 | `openclaw.extensions` in package.json | `package.json:28-29` — `"openclaw": { "extensions": ["./dist/index.js"] }` | PASS |
-| `openclaw.plugin.json` manifest with `id`, `extensions`, `configSchema` | `openclaw.plugin.json` — id: `cycles-openclaw-budget-guard`, extensions: `["./dist/index.js"]` | PASS |
+| `openclaw.plugin.json` manifest with `id`, `extensions`, `configSchema` | `openclaw.plugin.json` — id: `openclaw-budget-guard`, extensions: `["./dist/index.js"]` | PASS |
 | Default export: `function(api: OpenClawPluginApi): void` | `src/index.ts:32` | PASS |
 | Named exports: error types and config types | `src/index.ts:21-30` — `BudgetExhaustedError`, `ToolBudgetDeniedError`, `BudgetGuardConfig`, `BudgetLevel`, `BudgetSnapshot`, `BudgetTransitionEvent`, `BudgetStatusMetadata`, `CostEstimatorContext`, `SessionSummary` | PASS |
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ openclaw plugins install -l ./cycles-openclaw-budget-guard
 ### 2. Enable the plugin
 
 ```bash
-openclaw plugins enable cycles-openclaw-budget-guard
+openclaw plugins enable openclaw-budget-guard
 ```
 
 ### 3. Add minimal configuration
@@ -71,7 +71,7 @@ Add the following to your OpenClaw config file (typically `openclaw.json` or `op
 {
   "plugins": {
     "entries": {
-      "cycles-openclaw-budget-guard": {
+      "openclaw-budget-guard": {
         "config": {
           "cyclesBaseUrl": "http://localhost:7878",
           "cyclesApiKey": "cyc_your_api_key_here",
@@ -104,7 +104,7 @@ To test without a live Cycles server:
 {
   "plugins": {
     "entries": {
-      "cycles-openclaw-budget-guard": {
+      "openclaw-budget-guard": {
         "config": {
           "tenant": "my-org",
           "cyclesBaseUrl": "http://unused",
@@ -124,7 +124,7 @@ To test without a live Cycles server:
 {
   "plugins": {
     "entries": {
-      "cycles-openclaw-budget-guard": {
+      "openclaw-budget-guard": {
         "config": {
           "enabled": true,
           "cyclesBaseUrl": "http://localhost:7878",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "cycles-openclaw-budget-guard",
+  "id": "openclaw-budget-guard",
   "name": "Cycles OpenClaw Budget Guard",
   "version": "0.3.1",
   "description": "OpenClaw plugin for budget-aware model and tool execution using Cycles.",


### PR DESCRIPTION
OpenClaw derives the plugin id from the npm package name by stripping the scope: @runcycles/openclaw-budget-guard → openclaw-budget-guard. The manifest id was "cycles-openclaw-budget-guard" causing a mismatch warning. Updated manifest id and all config/CLI references to use "openclaw-budget-guard".

https://claude.ai/code/session_01KWNNNo7hCJjEfVkrNLeL1d