### PR TITLE
fix: unwrap config key from OpenClaw plugin entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,13 @@ export type {
 } from "./types.js";
 
 export default function (api: OpenClawPluginApi): void {
-  const config = resolveConfig(api.config);
+  // OpenClaw wraps plugin config under a "config" key in the entry object.
+  // Unwrap if present so resolveConfig sees the flat config values.
+  const raw = api.config as Record<string, unknown>;
+  const unwrapped = (raw.config && typeof raw.config === "object" && !Array.isArray(raw.config))
+    ? raw.config as Record<string, unknown>
+    : raw;
+  const config = resolveConfig(unwrapped);
 
   if (!config.enabled) {
     return;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -135,7 +135,7 @@ describe("plugin entrypoint", () => {
     }
   });
 
-  it("calls resolveConfig with api.config", () => {
+  it("calls resolveConfig with api.config when flat", () => {
     const rawConfig = { tenant: "test" };
     mockResolveConfig.mockReturnValue(makeConfig());
 
@@ -147,6 +147,20 @@ describe("plugin entrypoint", () => {
 
     registerPlugin(api);
     expect(mockResolveConfig).toHaveBeenCalledWith(rawConfig);
+  });
+
+  it("unwraps config wrapper when OpenClaw nests under config key", () => {
+    const inner = { tenant: "test", cyclesBaseUrl: "http://localhost:7878" };
+    mockResolveConfig.mockReturnValue(makeConfig());
+
+    const api = {
+      config: { config: inner },
+      logger: makeLogger(),
+      on: vi.fn(),
+    };
+
+    registerPlugin(api);
+    expect(mockResolveConfig).toHaveBeenCalledWith(inner);
   });
 
   it("calls initHooks with resolved config and api.logger", () => {


### PR DESCRIPTION
OpenClaw passes the entire plugin entry object to api.config, with user config nested under a "config" key. The plugin now unwraps this automatically so resolveConfig receives the flat config values.

https://claude.ai/code/session_01KWNNNo7hCJjEfVkrNLeL1d