### PR TITLE
fix: add defaultModelName config for OpenClaw which doesn't pass mode…

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -102,6 +102,10 @@
         "default": 500000,
         "description": "Fallback cost per model completion when model is not in modelBaseCosts."
       },
+      "defaultModelName": {
+        "type": "string",
+        "description": "Model name to use for budget reservations when OpenClaw does not pass the model name in the hook event. Set this to your agent's model (e.g. 'openai/gpt-5-nano')."
+      },
       "userId": {
         "type": "string",
         "description": "Optional user identifier for per-user budget scoping."

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,6 +106,7 @@ export function resolveConfig(
     // Gap 1: LLM call reservations
     modelBaseCosts: asNumberRecord(raw.modelBaseCosts) ?? {},
     defaultModelCost: asNumber(raw.defaultModelCost) ?? 500_000,
+    defaultModelName: asString(raw.defaultModelName),
 
     // Gap 2: Actual cost tracking
     costEstimator: asFunction(raw.costEstimator) as BudgetGuardConfig["costEstimator"],

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -460,15 +460,17 @@ export async function beforeModelResolve(
 
   const snapshot = await getSnapshot(ctx);
 
-  // Guard against undefined model name — try common field names from OpenClaw
+  // Resolve model name from event — OpenClaw may pass it in different fields,
+  // or not at all (only 'prompt' key). Fall back to config.defaultModelName.
   const eventRecord = event as Record<string, unknown>;
   const eventModel = event.model
     ?? eventRecord.modelId as string | undefined
     ?? eventRecord.modelName as string | undefined
     ?? eventRecord.model_id as string | undefined
-    ?? eventRecord.model_name as string | undefined;
+    ?? eventRecord.model_name as string | undefined
+    ?? config.defaultModelName;
   if (!eventModel) {
-    logger.warn(`before_model_resolve: model name is undefined in event — skipping budget reservation. Event keys: ${Object.keys(event).join(", ")}`);
+    logger.warn(`before_model_resolve: cannot determine model name (event keys: ${Object.keys(event).join(", ")}). Set defaultModelName in plugin config to enable model budget tracking.`);
     attachBudgetStatus(ctx, snapshot);
     return undefined;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface BudgetGuardConfig {
   // Phase 1 — Gap 1: LLM call reservations
   modelBaseCosts: Record<string, number>;
   defaultModelCost: number;
+  defaultModelName?: string;
 
   // Phase 1 — Gap 2: Actual cost tracking
   costEstimator?: (context: CostEstimatorContext) => number | undefined;

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -36,6 +36,7 @@ export function makeConfig(
     // Gap 1
     modelBaseCosts: {},
     defaultModelCost: 500_000,
+    defaultModelName: undefined,
     // Gap 2
     costEstimator: undefined,
     // Gap 3

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1981,7 +1981,7 @@ describe("v0.5.0 — model reserve-then-commit", () => {
 
     expect(result).toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining("model name is undefined"),
+      expect.stringContaining("cannot determine model name"),
     );
     expect(mockReserveBudget).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
…l in event

OpenClaw's before_model_resolve hook passes { prompt: ... } with no model field. The plugin tried event.model, modelId, modelName, model_id, model_name — all undefined. Budget enforcement for model calls was completely skipped.

Fix: Add defaultModelName config property. When the event doesn't contain a model name, fall back to this config value. Users set it to their agent's model (e.g. "openai/gpt-5-nano") and model budget tracking works.

Without defaultModelName set, the plugin logs a clear warning: "cannot determine model name ... Set defaultModelName in plugin config to enable model budget tracking."

https://claude.ai/code/session_016JXYAGrQ9bFio4BQpVP9V4