### PR TITLE
fix: remove `name` from init context fallback — it resolves to plugin…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,6 @@ export default function (api: OpenClawPluginApi): void {
       ?? asString(apiRecord.channel)
       ?? asString(apiRecord.workerId)
       ?? asString(apiRecord.id)
-      ?? asString(apiRecord.name)
       ?? asString(apiRecord.scope);
     const contextLabel = context ? `, context=${context}` : `, instance=${++initCount}`;
     api.logger.info(`Cycles Budget Guard initialized (tenant=${config.tenant}, dryRun=${config.dryRun}${contextLabel})`);


### PR DESCRIPTION
… name, not channel ID

apiRecord.name returns "openclaw-budget-guard" (the plugin's own manifest name) for all instances, so context=openclaw-budget-guard appears 4 times identically. Removed from the fallback chain so it falls through to instance=N counter which actually differentiates channels.

https://claude.ai/code/session_016JXYAGrQ9bFio4BQpVP9V4