### PR TITLE
Upgrade TypeScript 5.9.3 → 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.1.0",
         "tsup": "^8.0.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "vitest": "^4.1.0"
       },
       "engines": {
@@ -2648,9 +2648,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.1.0",
     "tsup": "^8.0.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vitest": "^4.1.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "rootDir": "src",
     "lib": ["ES2022"],
     "types": ["node"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
Upgrades TypeScript from 5.9.3 to 6.0.2 with the necessary tsconfig changes:
- Bumps `typescript` to `^6.0.2` in package.json
- Adds `\"ignoreDeprecations\": \"6.0\"` to tsconfig.json — tsup internally uses the deprecated `baseUrl` option for DTS generation, which fails without this flag in TS6
- Supersedes #46 (Dependabot PR) which couldn't pass CI without the tsconfig fix.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes (including DTS generation)\n- [x] All 300 tests pass on Node 20 and Node 22

https://claude.ai/code/session_01MAZ8fhiBJKEkZmvMCH8Ysq