### PR TITLE
fix: strip provider prefix from modelOverride to prevent double-prefi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The plugin uses a simple model: every model call and tool call reserves a fixed 
 - `web_search` at 500,000/call = ~1,000 calls
 - `lowBudgetThreshold: 10000000` triggers model downgrade when $0.10 remains
 
-**Model names.** OpenClaw passes model identifiers in `provider/model` format (e.g., `openai/gpt-4o`, `anthropic/claude-sonnet-4-20250514`). Your `modelBaseCosts`, `modelFallbacks`, and `defaultModelName` must use the same format — bare model names like `gpt-4o` won't match.
+**Model names.** OpenClaw passes model identifiers in `provider/model` format (e.g., `openai/gpt-4o`, `anthropic/claude-sonnet-4-20250514`). Your `modelBaseCosts`, `modelFallbacks`, and `defaultModelName` must use the same format — bare model names like `gpt-4o` won't match. The plugin automatically strips the provider prefix when returning `modelOverride` to OpenClaw, so you can use `provider/model` consistently in all config fields without double-prefixing issues.
 
 **Setting toolBaseCosts.** Start with the default (100,000 units per call). After your first session, check the `unconfiguredTools` list in the session summary — it tells you which tools need explicit costs. For tools that call external APIs, estimate higher (500K-1M). For lightweight tools, estimate lower (10K-50K).
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -631,7 +631,13 @@ export async function beforeModelResolve(
   }
 
   if (resolvedModel !== eventModel) {
-    return { modelOverride: resolvedModel };
+    // OpenClaw prepends the provider prefix to modelOverride values,
+    // so strip any provider/ prefix to avoid double-prefixing
+    // (e.g., "openai/gpt-5-nano" → "gpt-5-nano" → OpenClaw adds "openai/" → "openai/gpt-5-nano")
+    const overrideValue = resolvedModel.includes("/")
+      ? resolvedModel.split("/").slice(1).join("/")
+      : resolvedModel;
+    return { modelOverride: overrideValue };
   }
   return undefined;
 }

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -305,6 +305,23 @@ describe("beforeModelResolve", () => {
     expect(result).toEqual({ modelOverride: "gpt-4o-mini" });
   });
 
+  it("strips provider prefix from modelOverride to avoid double-prefixing", async () => {
+    setup({
+      modelFallbacks: { "openai/gpt-5-mini": "openai/gpt-5-nano" },
+      modelBaseCosts: { "openai/gpt-5-nano": 500 },
+    });
+    mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "low", remaining: 5_000_000 }));
+    mockIsAllowed.mockReturnValue(true);
+    mockReserveBudget.mockResolvedValue({ decision: "ALLOW", reservationId: "r1", affectedScopes: [] });
+
+    const result = await beforeModelResolve(
+      { model: "openai/gpt-5-mini" },
+      makeHookContext(),
+    );
+    // OpenClaw prepends the provider, so plugin strips "openai/" to avoid "openai/openai/gpt-5-nano"
+    expect(result).toEqual({ modelOverride: "gpt-5-nano" });
+  });
+
   it("supports chained fallbacks (Gap 4)", async () => {
     setup({
       modelFallbacks: { "opus": ["sonnet", "haiku"] },


### PR DESCRIPTION
…xing

OpenClaw prepends the provider prefix to modelOverride values. When users configure modelFallbacks with provider/model format (e.g., "openai/gpt-5-nano"), the plugin returned it as-is, causing OpenClaw to produce "openai/openai/gpt-5-nano". Now strips the prefix before returning the override so users can use provider/model consistently in all config fields.

https://claude.ai/code/session_018mXxQ4TBuKH7xf6dXujrMF

## Summary

<!-- What does this PR do? Why? -->

## Checklist

- [X] Tests added/updated for new behavior
- [X] `AUDIT.md` updated (if protocol surface changed)
- [X] `README.md` updated (if public API changed)
- [X] Lint and test suite passes locally

## Test plan

<!-- How was this tested? What commands were run? -->
