### PR TITLE
Claude/fix openclaw budget error va ya e

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,25 +625,33 @@ The `costEstimator` receives a context object with `toolName`, `durationMs`, `es
 |-------|------|---------|-------------|
 | `enableEventLog` | boolean | `false` | Record every reserve/commit/deny/block decision in `sessionSummary.eventLog` |
 
-### Function-Type Config (Advanced)
+### Function-Type Config — Not Available in OpenClaw
 
-Several config parameters require JavaScript functions (`costEstimator`, `modelCostEstimator`, `onBudgetTransition`, `onSessionEnd`, `onBurnRateAnomaly`, `onExhaustionForecast`, `metricsEmitter`). These **cannot be set in JSON config files**.
+The config reference includes several function-type parameters (`costEstimator`, `modelCostEstimator`, `onBudgetTransition`, `onSessionEnd`, `onBurnRateAnomaly`, `onExhaustionForecast`, `metricsEmitter`). **These cannot be used with OpenClaw.** OpenClaw plugins are configured via JSON only — there is no mechanism to pass JavaScript functions.
 
-**Most users don't need them.** Every function parameter has a JSON-configurable alternative:
+Use these JSON-configurable alternatives instead:
 
-| Function param | JSON alternative | What the alternative does |
+| Instead of... | Use... | How it works |
 |---|---|---|
-| `costEstimator` | `toolBaseCosts` | Fixed cost per tool (covers most cases) |
-| `modelCostEstimator` | `modelBaseCosts` | Fixed cost per model |
-| `onBudgetTransition` | `budgetTransitionWebhookUrl` | HTTP POST on level change |
-| `onSessionEnd` | `analyticsWebhookUrl` | HTTP POST with session summary |
-| `onBurnRateAnomaly` | `otlpMetricsEndpoint` | Metrics emitted to OTLP backend |
-| `onExhaustionForecast` | `otlpMetricsEndpoint` | Metrics emitted to OTLP backend |
-| `metricsEmitter` | `otlpMetricsEndpoint` | Auto-creates an OTLP emitter |
+| `costEstimator` | `toolBaseCosts` | Fixed cost per tool. Tune estimates using session summary data. |
+| `modelCostEstimator` | `modelBaseCosts` | Fixed cost per model. |
+| `onBudgetTransition` | `budgetTransitionWebhookUrl` | Sends HTTP POST with level change event to your endpoint. |
+| `onSessionEnd` | `analyticsWebhookUrl` | Sends HTTP POST with full session summary to your endpoint. |
+| `onBurnRateAnomaly` | `otlpMetricsEndpoint` | Emits `cycles.budget.burn_rate_anomaly` counter to your OTLP backend. |
+| `onExhaustionForecast` | `otlpMetricsEndpoint` | Emits `cycles.budget.exhaustion_forecast_ms` gauge to your OTLP backend. |
+| `metricsEmitter` | `otlpMetricsEndpoint` | Auto-creates an OTLP emitter — no custom code needed. |
 
-The JSON alternatives cover the most common use cases. Use `toolBaseCosts`/`modelBaseCosts` for cost estimation, webhook URLs for notifications, and `otlpMetricsEndpoint` for observability.
+**Tuning cost estimates without a callback:**
 
-Function params are available for applications that import the plugin as a library and call it programmatically (e.g., custom agent frameworks, test harnesses, or wrappers that build on top of OpenClaw). They are not used in standard OpenClaw JSON plugin configuration.
+1. Start with rough values in `toolBaseCosts` / `modelBaseCosts` (or use defaults)
+2. Set `enableEventLog: true` in your config
+3. Run a few agent sessions
+4. Check the session summary in the logs — it shows per-tool and per-model cost breakdowns, plus an `unconfiguredTools` list of tools using the default estimate
+5. Adjust your cost values based on actual usage patterns and re-run
+
+This iterative approach is more practical than writing a cost estimator function, since the estimates only need to be "close enough" — Cycles reservations lock the estimated amount and commits charge the actual.
+
+> **Why do the function params exist?** The plugin is also published as an npm package. The function API is available for developers who import the plugin as a library in custom agent frameworks or test harnesses — not for standard OpenClaw JSON config.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

- **Title is honest**: "Function-Type Config — Not Available in OpenClaw"
- **Alternatives table** shows exactly what to use instead, with specific OTLP metric names
- **Cost tuning workflow** — 5-step iterative process using session summaries instead of callbacks
- **Footnote** explains why the function params exist (npm library API for custom frameworks)

No more confusion about "where to write the startup script."
<!-- What does this PR do? Why? -->

## Checklist

- [ ] Tests added/updated for new behavior
- [ ] `AUDIT.md` updated (if protocol surface changed)
- [ ] `README.md` updated (if public API changed)
- [ ] Lint and test suite passes locally

## Test plan

<!-- How was this tested? What commands were run? -->
