### PR TITLE
fix: update npm to latest before publish to fix missing README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
           cache: npm
           registry-url: "https://registry.npmjs.org"
 
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
 


### PR DESCRIPTION
npm reads README from package metadata, not the tarball. Some npm 10.x versions (bundled with Node 20) have a bug where the readme field is not populated during publish. Adding npm install -g npm@latest ensures the latest CLI is used.

https://claude.ai/code/session_018mXxQ4TBuKH7xf6dXujrMF

## Summary

<!-- What does this PR do? Why? -->

## Checklist

- [ ] Tests added/updated for new behavior
- [ ] `AUDIT.md` updated (if protocol surface changed)
- [ ] `README.md` updated (if public API changed)
- [ ] Lint and test suite passes locally

## Test plan

<!-- How was this tested? What commands were run? -->
