### PR TITLE
fix: replace nonexistent /v1/scopes endpoint with correct budgets/fun…

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,17 +591,20 @@ tenant: "my-org"           ← shared across all apps
   app: "coding-agent"      ← $10 budget (budgetId)
 ```
 
-**Step 1: Create the app-level budget in Cycles** (via the Admin API):
+**Step 1: Create and fund the app-level budget in Cycles** (via the Admin API):
 
 ```bash
-curl -X POST http://localhost:7979/v1/scopes \
+curl -X POST "http://localhost:7979/v1/admin/budgets/fund?scope=tenant:my-org/app:research-agent&unit=USD_MICROCENTS" \
+  -H "X-Cycles-API-Key: your-admin-key" \
   -H "Content-Type: application/json" \
   -d '{
-    "tenant": "my-org",
-    "app": "research-agent",
-    "allocated": { "unit": "USD_MICROCENTS", "amount": 500000000 }
+    "operation": "CREDIT",
+    "amount": 500000000,
+    "idempotency_key": "fund-research-agent-001"
   }'
 ```
+
+This creates the `app:research-agent` scope under `tenant:my-org` and funds it with 500,000,000 units ($5.00). The scope is created automatically if it doesn't exist.
 
 **Step 2: Set `budgetId` in the plugin config:**
 


### PR DESCRIPTION
…d endpoint

The budgetId documentation used POST /v1/scopes which doesn't exist in the Cycles server. Replaced with the correct Admin API endpoint POST /v1/admin/budgets/fund which auto-creates the scope and funds it.

Fixes #67

https://claude.ai/code/session_018mXxQ4TBuKH7xf6dXujrMF

## Summary

<!-- What does this PR do? Why? -->

## Checklist

- [ ] Tests added/updated for new behavior
- [ ] `AUDIT.md` updated (if protocol surface changed)
- [ ] `README.md` updated (if public API changed)
- [ ] Lint and test suite passes locally

## Test plan

<!-- How was this tested? What commands were run? -->
