### PR TITLE
test(hooks): tighten webhook URL match from substring to exact

### DIFF
--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -2913,9 +2913,11 @@ describe("v0.7.10 — webhook timeout", () => {
     mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "low", remaining: 5_000_000 }));
     await beforeModelResolve({ model: "gpt-4o" }, makeHookContext());
 
-    // Webhook must have been called with AbortSignal
+    // Webhook must have been called with AbortSignal. Match the exact
+    // configured URL rather than a substring — substring matching on URLs
+    // is a CodeQL/lint anti-pattern even in tests.
     const webhookCall = mockFetch.mock.calls.find(
-      (c) => typeof c[0] === "string" && c[0].includes("example.com"),
+      (c) => c[0] === "https://example.com/hook",
     );
     expect(webhookCall).toBeDefined();
     expect(webhookCall![1]).toHaveProperty("signal");


### PR DESCRIPTION
## Summary

Clears CodeQL alert `js/incomplete-url-substring-sanitization` (high severity) on `tests/hooks.test.ts:2918`.

The original test used `c[0].includes(\"example.com\")` to find a mock fetch call by URL substring. Even in test code, CodeQL flags this pattern because in production it would let `https://evil.com/example.com/path` slip past — and copy-paste from tests into production is a real risk.

## Change

```diff
-    const webhookCall = mockFetch.mock.calls.find(
-      (c) => typeof c[0] === \"string\" && c[0].includes(\"example.com\"),
-    );
+    const webhookCall = mockFetch.mock.calls.find(
+      (c) => c[0] === \"https://example.com/hook\",
+    );
```

The test is now stricter — it matches the exact configured URL, not any URL containing the substring.

## Test plan

- [x] `npm test` — all 352 tests pass
- [ ] CI green
- [ ] CodeQL re-analysis clears alert #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)