### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes require review from the repo owner.
+* @amavashev


### PR DESCRIPTION
Adds `CODEOWNERS` so every PR auto-requests review from the repo owner. Advisory until branch protection enforces "Require review from Code Owners".