### PR TITLE
docs: add MAINTAINERS.md (matches cycles-server template)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,36 @@
+# Maintainers
+
+This document lists the people responsible for triaging issues, reviewing PRs, and cutting releases for `cycles-openclaw-budget-guard` (the OpenClaw plugin for budget-aware model and tool execution using Cycles).
+
+## Project lead
+
+- **Albert Mavashev** — [@amavashev](https://github.com/amavashev) — primary committer, release manager
+
+## Contributing organizations
+
+The project receives contributions from:
+
+- [Runcycles](https://github.com/runcycles)
+- [K2NIO](https://github.com/K2NIO)
+- Singleton Labs
+
+## Responsibilities
+
+| Area | Owner | SLA |
+|---|---|---|
+| Issue triage | Project lead | 5 business days for first response |
+| PR review | Project lead | 3 business days for initial review |
+| Security disclosures | See [SECURITY.md](https://github.com/runcycles/.github/blob/main/SECURITY.md) | 48h acknowledgment, 5 business days assessment |
+| Release cuts | Project lead | Per repository tags |
+| Dependency updates | Dependabot + project lead | Auto-merge on patch updates passing CI; manual review on minor/major |
+| OpenClaw compatibility | Project lead | Track upstream OpenClaw releases; bump compatibility per major upstream change |
+
+## Becoming a maintainer
+
+We're a small team and add maintainers cautiously. Path is usually: sustained contribution (≥3 substantive PRs) → triage assistance → invitation to commit access. Open a discussion if you're interested.
+
+## How to reach maintainers
+
+- **General questions / bug reports**: [GitHub Issues](https://github.com/runcycles/cycles-openclaw-budget-guard/issues)
+- **Security disclosures**: see [SECURITY.md](https://github.com/runcycles/.github/blob/main/SECURITY.md) (do **not** open a public issue)
+- **Conduct concerns**: see the org-wide [Code of Conduct](https://github.com/runcycles/.github/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Org consistency. Same template as [cycles-server](https://github.com/runcycles/cycles-server/blob/main/MAINTAINERS.md), adapted for OpenClaw upstream tracking.