### PR TITLE
ci: auto-create GitHub Release on `v*` tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,16 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release:
+    name: Create GitHub Release
+    needs: [test, verify, publish]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release with auto-generated notes
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- Adds a `release` job to `.github/workflows/ci.yml` that runs after `test`, `verify`, and `publish` on tag pushes matching `v*`.
- Uses `softprops/action-gh-release@v3.0.0` (pinned by SHA `b4309332981a82ec1c5618f44dd2e27cc8bfbfda`) with `generate_release_notes: true` — same shape as the auto-generated commit list in v0.8.2 and earlier releases.
- Permissions scoped tight: workflow-level stays `contents: read`; `contents: write` is granted only to the `release` job. `publish` retains its own `id-token: write` for npm provenance.

## Why

The CI workflow only published to npm on tag — no GitHub Release was ever created automatically. The v0.8.3 release had to be created manually after the fact. With this in place, every future `v*` tag push produces the GitHub Release alongside the npm publish, no manual step required.

## Test plan

- [x] YAML parses cleanly (`python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`)
- [x] `release` job is gated on `if: startsWith(github.ref, 'refs/tags/v')` — won't run on PR or main pushes
- [x] `release` job depends on `[test, verify, publish]` — won't fire if any prior job fails
- [x] Action SHA matches `softprops/action-gh-release` v3.0.0 tag (verified via `gh api repos/softprops/action-gh-release/git/refs/tags/v3.0.0`)
- [ ] Manual end-to-end: next tag push creates a GitHub Release automatically (will verify on the next release cut)

## Notes

- v0.8.3 release was created manually before this PR; this only affects future tags.
- If you want richer release notes (e.g. extracting from CHANGELOG.md instead of auto-gen), say so and I'll switch to `body_path` with a small extraction step.