### PR TITLE
chore(seo): retarget README header for category-search discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cycles-openclaw-budget-guard
+# Cycles Budget Guard for OpenClaw — AI agent runtime control plugin
 
 [![CI](https://github.com/runcycles/cycles-openclaw-budget-guard/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/runcycles/cycles-openclaw-budget-guard/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@runcycles/openclaw-budget-guard)](https://www.npmjs.com/package/@runcycles/openclaw-budget-guard)
@@ -7,7 +7,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/runcycles/cycles-openclaw-budget-guard/actions)
 
-OpenClaw plugin for budget-aware model and tool execution using [Cycles](https://github.com/runcycles).
+**OpenClaw plugin for AI agent runtime control — enforce LLM cost limits, tool call caps, action permissions, and audit trails on OpenClaw agents before execution.** Drops in as `openclaw plugins install @runcycles/openclaw-budget-guard`. No agent code changes for typical setups. Powered by [Cycles](https://github.com/runcycles).
 
 ## Why use this plugin?
 


### PR DESCRIPTION
## Summary
Fixes the worst README SEO offender across the org. The H1 was the **bare repo slug** (`cycles-openclaw-budget-guard`), with no description or value prop visible above the badges, and the first indexed paragraph led with brand framing.

The README is what gets shown on:
- the [npm package page](https://www.npmjs.com/package/@runcycles/openclaw-budget-guard)
- the GitHub repo landing page
- Google search snippets for any of those URLs

A bare-slug H1 in that position systematically loses readers arriving from category-search queries.

## Two changes (+2 / -2)

### 1. H1 retitled

| | |
|---|---|
| Old | `# cycles-openclaw-budget-guard` |
| New | `# Cycles Budget Guard for OpenClaw — AI agent runtime control plugin` |

### 2. First paragraph retargeted to the three pillars

| | |
|---|---|
| Old | `OpenClaw plugin for budget-aware model and tool execution using Cycles.` |
| New | `OpenClaw plugin for AI agent runtime control — enforce LLM cost limits, tool call caps, action permissions, and audit trails on OpenClaw agents before execution. Drops in as openclaw plugins install @runcycles/openclaw-budget-guard. No agent code changes for typical setups.` |

Matches the package metadata refresh shipped in **v0.8.4** (PR #98). Body of the README is unchanged — only the H1 and lead paragraph.

## When this takes effect
- **GitHub**: immediate on merge.
- **npm package page**: on the next version publish (the README is bundled with each published version on npm).

## Test plan
- [ ] Merge.
- [ ] Verify the GitHub repo landing page renders correctly with the new H1.
- [ ] Next time a release ships from this repo, confirm npm shows the updated README on the package page.
