### PR TITLE
Fix concurrent hook runtime isolation and commit cleanup

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,7 +1,7 @@
 # cycles-openclaw-budget-guard — Plugin Audit
 
-**Date:** 2026-05-06
-**Plugin:** `@runcycles/openclaw-budget-guard` v0.8.3
+**Date:** 2026-07-18
+**Plugin:** `@runcycles/openclaw-budget-guard` v0.8.4 + unreleased fixes
 **Runtime:** OpenClaw >= 0.1.0, Node 20+
 **Cycles client:** `runcycles` ^0.3.0
 
@@ -25,9 +25,43 @@
 | Prompt Hint Formatting | — | 0 |
 | Session Summary & Metadata | — | 0 |
 | Published Package Contents (`files` field) | — | 0 |
-| Code Review (logic, safety, types) | 14 found | 9 fixed, 5 accepted |
+| Code Review (logic, safety, types) | 14 found | 10 fixed, 4 accepted |
 
-**Overall: Plugin is contract-conformant and production-ready.** All 62 config properties (54 JSON-serializable + 8 callbacks), 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and correctly tested. v0.5.0 adds model reserve-then-commit, MetricsEmitter, StandardMetrics, aggressive cache invalidation, and OTLP adapter. v0.6.0 adds heartbeat, retry, burn rate detection, event log, unconfigured tool report, and exhaustion forecast. v0.7.x adds branded startup, consistent naming, single-source version, process.env removal, model name auto-detection, and reservation lifecycle fixes. v0.7.6–v0.7.9 fix budget enforcement bugs, config validation gaps, and documentation. v0.7.10 fixes glob matching, record validation, webhook timeout, metrics flush, event log performance, DryRunClient ID isolation, model reservation cleanup, null cost estimator handling, budget fetch timeout, config validation for strategies/fallbacks/negative costs, error prefix consistency, and prompt hint truncation edge case. v0.8.0 adds `budgetScope` for full scope hierarchy targeting. v0.8.1 fixes case-insensitive scope matching. v0.8.2 fixes tenant-only config checking wrong budget scope (#76). v0.8.3 hardens against snapshot-fetch-bypass, webhook SSRF, OTLP collector hangs, and TTL/retry typos; adds `failClosedOnSnapshotError`, URL validation, OTLP request timeout, and TTL/retry bounds.
+**Overall: Plugin is contract-conformant and production-ready.** All 62 config properties (54 JSON-serializable + 8 callbacks), 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and correctly tested. v0.5.0 adds model reserve-then-commit, MetricsEmitter, StandardMetrics, aggressive cache invalidation, and OTLP adapter. v0.6.0 adds heartbeat, retry, burn rate detection, event log, unconfigured tool report, and exhaustion forecast. v0.7.x adds branded startup, consistent naming, single-source version, process.env removal, model name auto-detection, and reservation lifecycle fixes. v0.7.6–v0.7.9 fix budget enforcement bugs, config validation gaps, and documentation. v0.7.10 fixes glob matching, record validation, webhook timeout, metrics flush, event log performance, DryRunClient ID isolation, model reservation cleanup, null cost estimator handling, budget fetch timeout, config validation for strategies/fallbacks/negative costs, error prefix consistency, and prompt hint truncation edge case. v0.8.0 adds `budgetScope` for full scope hierarchy targeting. v0.8.1 fixes case-insensitive scope matching. v0.8.2 fixes tenant-only config checking wrong budget scope (#76). v0.8.3 hardens against snapshot-fetch-bypass, webhook SSRF, OTLP collector hangs, and TTL/retry typos; adds `failClosedOnSnapshotError`, URL validation, OTLP request timeout, and TTL/retry bounds. The unreleased fix isolates all mutable enforcement state by OpenClaw session/run identity and verifies concurrent lifecycle cleanup with interleaved regression tests.
+
+---
+
+## Unreleased Changes (2026-07-18)
+
+### Concurrent session correctness
+
+| Fix | Description | Location |
+|---|---|---|
+| Session-scoped lifecycle state | Replaced process-global reservation, pending-model, cost, cache, limit, event-log, forecast, and heartbeat state with `SessionState` entries keyed by the OpenClaw hook scope. Identity preference is `sessionId` → `sessionKey`/`conversationId` → `runId` → configured `sessionId` → `agentId` → `userId` → documented tenant fallback. | `src/hooks.ts:SessionState`, `resolveScope`, `getSessionState` |
+| Pending model isolation | Each session/run now owns its own pending model reservation and model name, so an interleaved model call in session B cannot replace or commit session A's hold. | `src/hooks.ts:commitPendingModelReservation`, `beforeModelResolve`, `beforePromptBuild`, `agentEnd` |
+| Reservation and heartbeat cleanup | Tool reservations and heartbeat timers are looked up within the invoking session. Commit stops only that call's timer; `agent_end` stops only that session's timers, releases only its orphaned holds, and removes its state in a `finally` block on every error path. | `src/hooks.ts:startHeartbeat`, `stopHeartbeat`, `stopAllHeartbeats`, `afterToolCall`, `agentEnd` |
+| Host hook context contract | Hook context types now include OpenClaw's direct `sessionId`, `sessionKey`, `runId`, `agentId`, and model fields while retaining legacy `metadata` compatibility. | `src/types.ts:HookContext` |
+
+### Regression coverage
+
+- Added two-session lifecycle tests that deliberately interleave pending model
+  reservations and reuse a tool call ID across sessions. They verify model
+  commits, tool commits/releases, summaries, costs, call counts, and heartbeat
+  ownership have zero cross-talk.
+- Added an interleaved commit-error test proving the failing session's heartbeat
+  stops and its orphan is released without stopping or releasing the other
+  session's reservation.
+- Public hook registration and package API shapes are unchanged; no migration is
+  required. Hosts that omit every session/run identifier receive documented
+  best-effort isolation only.
+
+| Metric | Result |
+|---|---:|
+| Test count | 374 passing |
+| Statement coverage | 98.47% |
+| Branch coverage | 96.14% |
+| Function coverage | 99.13% |
+| Line coverage | 99.17% |
 
 ---
 
@@ -648,6 +682,19 @@ DryRunClient hardcoded `"USD_MICROCENTS"` for all balance units. When users conf
 
 **Fix:** Added `currency` constructor parameter. `initHooks` passes `config.currency`. Test updated.
 
+#### 8. Process-global hook lifecycle state
+
+**File:** `src/hooks.ts`
+**Severity:** High — Concurrent sessions could commit, attribute, or release each other's budget holds
+
+Reservations, pending model state, cost totals, caches, counters, event logs,
+forecasts, and heartbeat timers were shared module singletons. In particular,
+one pending-model slot allowed session B to overwrite session A's hold.
+
+**Fix:** Moved every lifecycle value into `SessionState`, keyed by OpenClaw's
+session/run identity. Added interleaved two-session commit/release and error-path
+tests, including colliding tool call IDs and heartbeat ownership assertions.
+
 ### Issues Accepted (No Fix Needed)
 
 #### 4. Stale snapshot.level in retry success path
@@ -676,15 +723,6 @@ Webhooks are non-blocking best-effort. Errors are caught and logged but delivery
 Response bodies from runcycles are cast without runtime validation.
 
 **Accepted:** The runcycles SDK validates responses internally. `DryRunClient` is only called by our own typed code.
-
-#### 7. Module-level mutable state
-
-**File:** `src/hooks.ts:48-85`
-**Severity:** Low
-
-Plugin uses module-level variables reset in `initHooks()`. Not safely reentrant for concurrent instances.
-
-**Accepted:** OpenClaw guarantees single-instance initialization. Module-level state is the standard plugin pattern. `initHooks()` resets all state completely.
 
 #### 8. Model costs are estimated, not actual
 
@@ -783,7 +821,7 @@ Overage policy values used `ALLOW` and `ALLOW_WITH_CAPS` (which are `Decision` e
 
 ## Verdict
 
-The plugin is **production-ready and contract-conformant** with OpenClaw plugin requirements. All 45 config properties, 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent, correctly tested (200 tests, 100% line coverage, 99% branch coverage), and reviewed for correctness. Nine code issues were identified and fixed (including 3 runcycles spec inconsistencies, 2 network error handling gaps, and 1 concurrency safety fix); five were reviewed and accepted as reasonable design choices.
+The plugin is **production-ready and contract-conformant** with OpenClaw plugin requirements. All 62 config properties, 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and reviewed for correctness. The current suite passes 374 tests with 98.47% statement, 96.14% branch, and 99.17% line coverage. Ten code issues were identified and fixed, including runcycles spec inconsistencies, network error handling gaps, and concurrent-session state isolation; four were reviewed and accepted as reasonable design choices.
 
 ---
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -40,8 +40,9 @@
 | Registration-scoped runtime | Each plugin entrypoint call now registers closures over a dedicated client, config, logger, metrics emitter, dry-run store, and session map. A later tenant/worker registration cannot redirect an in-flight session to another runtime. | `src/hooks.ts:createHooks`, `src/index.ts` |
 | Session-scoped lifecycle state | Replaced process-global reservation, pending-model, cost, cache, limit, event-log, forecast, and heartbeat state with `SessionState` entries keyed by the OpenClaw hook scope. Identity preference is `sessionId` → `sessionKey`/`conversationId` → `runId` → configured `sessionId` → `agentId` → `userId` → documented tenant fallback. | `src/hooks.ts:SessionState`, `resolveScope`, `getSessionState` |
 | Pending model isolation | Each session/run now owns its own pending model reservation and model name, so an interleaved model call in session B cannot replace or commit session A's hold. | `src/hooks.ts:commitPendingModelReservation`, `beforeModelResolve`, `beforePromptBuild`, `agentEnd` |
-| Observable commit outcomes | `commitUsage` now returns success/failure. Failed tool commits retain the hold for `agent_end`; failed final model commits are released; the next model reservation is not attempted until the prior model hold commits. | `src/cycles.ts:commitUsage`, `src/hooks.ts:commitPendingModelReservationFor`, `afterToolCallFor` |
+| Observable, fail-open commit outcomes | `commitUsage` now returns success/failure. Failed tool commits retain the hold for `agent_end`; pending model commit failures no longer reject pre-model hooks; the next model call is costed locally without creating a second hold; failed final model commits are released. | `src/cycles.ts:commitUsage`, `src/hooks.ts:commitPendingModelReservationFor`, `beforeModelResolveFor`, `beforePromptBuildFor`, `afterToolCallFor` |
 | Reservation and heartbeat cleanup | Tool reservations and heartbeat timers are looked up within the invoking session. Both successful and failed commits stop only that call's timer; `agent_end` stops only that session's timers, releases only its orphaned holds, and removes its state in a `finally` block on every error path. | `src/hooks.ts:startHeartbeatFor`, `stopHeartbeat`, `stopAllHeartbeats`, `afterToolCallFor`, `agentEndFor` |
+| Terminal state fencing | `after_tool_call` uses lookup-only state and no-ops when the scope is absent or already entering `agent_end`. Late/duplicate deliveries cannot resurrect deleted entries, grow the session map, or race a terminal release with a commit. | `src/hooks.ts:findSessionStateFor`, `SessionState.ending`, `afterToolCallFor`, `agentEndFor` |
 | Host hook context contract | Hook context types now include OpenClaw's direct `sessionId`, `sessionKey`, `runId`, `agentId`, and model fields while retaining legacy `metadata` compatibility. | `src/types.ts:HookContext` |
 
 ### Regression coverage
@@ -58,17 +59,21 @@
   cross tenant/runtime boundaries.
 - Added production-realistic non-success tests for tool and model commits,
   including the invariant that a failed pending model commit cannot create a
-  second hold. Public package API shape is unchanged; no migration is required.
-  Hosts that omit every session/run identifier receive documented best-effort
-  isolation only within a registration.
+  second hold. Model resolve and prompt-build tests assert these failures remain
+  non-throwing and that unreserved model cost is accounted locally.
+- Added terminal-delivery tests proving concurrent, late, and duplicate
+  `after_tool_call` events neither commit a releasing hold nor resurrect session
+  state after `agent_end`. Public package API shape is unchanged; no migration
+  is required. Hosts that omit every session/run identifier receive documented
+  best-effort isolation only within a registration.
 
 | Metric | Result |
 |---|---:|
-| Test count | 377 passing |
-| Statement coverage | 98.49% |
-| Branch coverage | 96.06% |
-| Function coverage | 99.34% |
-| Line coverage | 99.13% |
+| Test count | 380 passing |
+| Statement coverage | 98.23% |
+| Branch coverage | 95.64% |
+| Function coverage | 99.35% |
+| Line coverage | 98.83% |
 
 ---
 
@@ -702,9 +707,11 @@ one pending-model slot allowed session B to overwrite session A's hold.
 (client, config, logger, metrics, dry-run store, and session map). Every
 lifecycle value lives in `SessionState`, keyed by OpenClaw's session/run identity
 inside that runtime. Commit helpers expose non-success outcomes so failed tool
-holds remain releasable, failed final model holds are released, and a new model
-hold cannot be created while the previous commit is unresolved. Interleaved
-session and registration tests include colliding IDs and heartbeat ownership.
+holds remain releasable, transient model failures stay fail-open without a
+second hold, and failed final model holds are released. Lookup-only terminal
+access and an `ending` fence prevent late hooks from resurrecting state or
+racing cleanup. Interleaved session and registration tests include colliding
+IDs, terminal delivery, and heartbeat ownership.
 
 ### Issues Accepted (No Fix Needed)
 
@@ -832,7 +839,7 @@ Overage policy values used `ALLOW` and `ALLOW_WITH_CAPS` (which are `Decision` e
 
 ## Verdict
 
-The plugin is **production-ready and contract-conformant** with OpenClaw plugin requirements. All 62 config properties, 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and reviewed for correctness. The current suite passes 377 tests with 98.49% statement, 96.06% branch, 99.34% function, and 99.13% line coverage. Ten code issues were identified and fixed, including runcycles spec inconsistencies, network error handling gaps, and concurrent-session/runtime state isolation; four were reviewed and accepted as reasonable design choices.
+The plugin is **production-ready and contract-conformant** with OpenClaw plugin requirements. All 62 config properties, 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and reviewed for correctness. The current suite passes 380 tests with 98.23% statement, 95.64% branch, 99.35% function, and 98.83% line coverage. Ten code issues were identified and fixed, including runcycles spec inconsistencies, network error handling gaps, and concurrent-session/runtime state isolation; four were reviewed and accepted as reasonable design choices.
 
 ---
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -27,7 +27,7 @@
 | Published Package Contents (`files` field) | — | 0 |
 | Code Review (logic, safety, types) | 14 found | 10 fixed, 4 accepted |
 
-**Overall: Plugin is contract-conformant and production-ready.** All 62 config properties (54 JSON-serializable + 8 callbacks), 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and correctly tested. v0.5.0 adds model reserve-then-commit, MetricsEmitter, StandardMetrics, aggressive cache invalidation, and OTLP adapter. v0.6.0 adds heartbeat, retry, burn rate detection, event log, unconfigured tool report, and exhaustion forecast. v0.7.x adds branded startup, consistent naming, single-source version, process.env removal, model name auto-detection, and reservation lifecycle fixes. v0.7.6–v0.7.9 fix budget enforcement bugs, config validation gaps, and documentation. v0.7.10 fixes glob matching, record validation, webhook timeout, metrics flush, event log performance, DryRunClient ID isolation, model reservation cleanup, null cost estimator handling, budget fetch timeout, config validation for strategies/fallbacks/negative costs, error prefix consistency, and prompt hint truncation edge case. v0.8.0 adds `budgetScope` for full scope hierarchy targeting. v0.8.1 fixes case-insensitive scope matching. v0.8.2 fixes tenant-only config checking wrong budget scope (#76). v0.8.3 hardens against snapshot-fetch-bypass, webhook SSRF, OTLP collector hangs, and TTL/retry typos; adds `failClosedOnSnapshotError`, URL validation, OTLP request timeout, and TTL/retry bounds. The unreleased fix isolates all mutable enforcement state by OpenClaw session/run identity and verifies concurrent lifecycle cleanup with interleaved regression tests.
+**Overall: Plugin is contract-conformant and production-ready.** All 62 config properties (54 JSON-serializable + 8 callbacks), 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and correctly tested. v0.5.0 adds model reserve-then-commit, MetricsEmitter, StandardMetrics, aggressive cache invalidation, and OTLP adapter. v0.6.0 adds heartbeat, retry, burn rate detection, event log, unconfigured tool report, and exhaustion forecast. v0.7.x adds branded startup, consistent naming, single-source version, process.env removal, model name auto-detection, and reservation lifecycle fixes. v0.7.6–v0.7.9 fix budget enforcement bugs, config validation gaps, and documentation. v0.7.10 fixes glob matching, record validation, webhook timeout, metrics flush, event log performance, DryRunClient ID isolation, model reservation cleanup, null cost estimator handling, budget fetch timeout, config validation for strategies/fallbacks/negative costs, error prefix consistency, and prompt hint truncation edge case. v0.8.0 adds `budgetScope` for full scope hierarchy targeting. v0.8.1 fixes case-insensitive scope matching. v0.8.2 fixes tenant-only config checking wrong budget scope (#76). v0.8.3 hardens against snapshot-fetch-bypass, webhook SSRF, OTLP collector hangs, and TTL/retry typos; adds `failClosedOnSnapshotError`, URL validation, OTLP request timeout, and TTL/retry bounds. The unreleased fix binds all runtime dependencies per plugin registration, isolates mutable enforcement state by OpenClaw session/run identity, and makes commit failures observable for lifecycle cleanup.
 
 ---
 
@@ -37,9 +37,11 @@
 
 | Fix | Description | Location |
 |---|---|---|
+| Registration-scoped runtime | Each plugin entrypoint call now registers closures over a dedicated client, config, logger, metrics emitter, dry-run store, and session map. A later tenant/worker registration cannot redirect an in-flight session to another runtime. | `src/hooks.ts:createHooks`, `src/index.ts` |
 | Session-scoped lifecycle state | Replaced process-global reservation, pending-model, cost, cache, limit, event-log, forecast, and heartbeat state with `SessionState` entries keyed by the OpenClaw hook scope. Identity preference is `sessionId` → `sessionKey`/`conversationId` → `runId` → configured `sessionId` → `agentId` → `userId` → documented tenant fallback. | `src/hooks.ts:SessionState`, `resolveScope`, `getSessionState` |
 | Pending model isolation | Each session/run now owns its own pending model reservation and model name, so an interleaved model call in session B cannot replace or commit session A's hold. | `src/hooks.ts:commitPendingModelReservation`, `beforeModelResolve`, `beforePromptBuild`, `agentEnd` |
-| Reservation and heartbeat cleanup | Tool reservations and heartbeat timers are looked up within the invoking session. Commit stops only that call's timer; `agent_end` stops only that session's timers, releases only its orphaned holds, and removes its state in a `finally` block on every error path. | `src/hooks.ts:startHeartbeat`, `stopHeartbeat`, `stopAllHeartbeats`, `afterToolCall`, `agentEnd` |
+| Observable commit outcomes | `commitUsage` now returns success/failure. Failed tool commits retain the hold for `agent_end`; failed final model commits are released; the next model reservation is not attempted until the prior model hold commits. | `src/cycles.ts:commitUsage`, `src/hooks.ts:commitPendingModelReservationFor`, `afterToolCallFor` |
+| Reservation and heartbeat cleanup | Tool reservations and heartbeat timers are looked up within the invoking session. Both successful and failed commits stop only that call's timer; `agent_end` stops only that session's timers, releases only its orphaned holds, and removes its state in a `finally` block on every error path. | `src/hooks.ts:startHeartbeatFor`, `stopHeartbeat`, `stopAllHeartbeats`, `afterToolCallFor`, `agentEndFor` |
 | Host hook context contract | Hook context types now include OpenClaw's direct `sessionId`, `sessionKey`, `runId`, `agentId`, and model fields while retaining legacy `metadata` compatibility. | `src/types.ts:HookContext` |
 
 ### Regression coverage
@@ -51,17 +53,22 @@
 - Added an interleaved commit-error test proving the failing session's heartbeat
   stops and its orphan is released without stopping or releasing the other
   session's reservation.
-- Public hook registration and package API shapes are unchanged; no migration is
-  required. Hosts that omit every session/run identifier receive documented
-  best-effort isolation only.
+- Added a same-session-ID, two-registration test proving clients, configs,
+  pending models, tool holds, summaries, costs, releases, and timers cannot
+  cross tenant/runtime boundaries.
+- Added production-realistic non-success tests for tool and model commits,
+  including the invariant that a failed pending model commit cannot create a
+  second hold. Public package API shape is unchanged; no migration is required.
+  Hosts that omit every session/run identifier receive documented best-effort
+  isolation only within a registration.
 
 | Metric | Result |
 |---|---:|
-| Test count | 374 passing |
-| Statement coverage | 98.47% |
-| Branch coverage | 96.14% |
-| Function coverage | 99.13% |
-| Line coverage | 99.17% |
+| Test count | 377 passing |
+| Statement coverage | 98.49% |
+| Branch coverage | 96.06% |
+| Function coverage | 99.34% |
+| Line coverage | 99.13% |
 
 ---
 
@@ -691,9 +698,13 @@ Reservations, pending model state, cost totals, caches, counters, event logs,
 forecasts, and heartbeat timers were shared module singletons. In particular,
 one pending-model slot allowed session B to overwrite session A's hold.
 
-**Fix:** Moved every lifecycle value into `SessionState`, keyed by OpenClaw's
-session/run identity. Added interleaved two-session commit/release and error-path
-tests, including colliding tool call IDs and heartbeat ownership assertions.
+**Fix:** Each plugin registration now closes over an independent runtime
+(client, config, logger, metrics, dry-run store, and session map). Every
+lifecycle value lives in `SessionState`, keyed by OpenClaw's session/run identity
+inside that runtime. Commit helpers expose non-success outcomes so failed tool
+holds remain releasable, failed final model holds are released, and a new model
+hold cannot be created while the previous commit is unresolved. Interleaved
+session and registration tests include colliding IDs and heartbeat ownership.
 
 ### Issues Accepted (No Fix Needed)
 
@@ -821,7 +832,7 @@ Overage policy values used `ALLOW` and `ALLOW_WITH_CAPS` (which are `Decision` e
 
 ## Verdict
 
-The plugin is **production-ready and contract-conformant** with OpenClaw plugin requirements. All 62 config properties, 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and reviewed for correctness. The current suite passes 374 tests with 98.47% statement, 96.14% branch, and 99.17% line coverage. Ten code issues were identified and fixed, including runcycles spec inconsistencies, network error handling gaps, and concurrent-session state isolation; four were reviewed and accepted as reasonable design choices.
+The plugin is **production-ready and contract-conformant** with OpenClaw plugin requirements. All 62 config properties, 5 hook registrations, 4 Cycles API operations, and 18 feature gap implementations are internally consistent and reviewed for correctness. The current suite passes 377 tests with 98.49% statement, 96.06% branch, 99.34% function, and 99.13% line coverage. Ten code issues were identified and fixed, including runcycles spec inconsistencies, network error handling gaps, and concurrent-session/runtime state isolation; four were reviewed and accepted as reasonable design choices.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,16 @@ are in [`AUDIT.md`](AUDIT.md). This file is the summary index.
 
 ### Fixed
 
-- Isolated all mutable hook lifecycle state by the OpenClaw session/run scope.
-  Concurrent sessions no longer share pending model holds, active tool
-  reservations, cost totals, caches, call limits, event logs, forecasts, or
-  heartbeat timers. Session cleanup now stops and releases only that session's
-  resources, including commit-error paths. No public API migration is required.
+- Isolated every plugin registration's client, config, logger, metrics, dry-run
+  store, and session-state map, then isolated mutable lifecycle state by the
+  OpenClaw session/run scope inside that runtime. Concurrent sessions and
+  tenants no longer share pending model holds, active tool reservations, cost
+  totals, caches, call limits, event logs, forecasts, or heartbeat timers.
+- Made reservation commit outcomes explicit internally. Failed tool commits
+  retain their hold for session cleanup, failed final model commits are
+  released, and a new model hold is never created before the prior hold commits.
+  Heartbeats stop on successful commits, failed commits, release cleanup, and
+  all `agent_end` error paths. No public package API migration is required.
 
 ## [0.8.4] — 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,14 @@ are in [`AUDIT.md`](AUDIT.md). This file is the summary index.
   totals, caches, call limits, event logs, forecasts, or heartbeat timers.
 - Made reservation commit outcomes explicit internally. Failed tool commits
   retain their hold for session cleanup, failed final model commits are
-  released, and a new model hold is never created before the prior hold commits.
-  Heartbeats stop on successful commits, failed commits, release cleanup, and
-  all `agent_end` error paths. No public package API migration is required.
+  released, and transient model commit failures no longer reject pre-model
+  hooks. The next model call proceeds fail-open with local cost accounting but
+  without creating a second hold. Heartbeats stop on successful commits, failed
+  commits, release cleanup, and all `agent_end` error paths.
+- Prevented late or duplicate `after_tool_call` delivery from recreating state
+  after `agent_end`. Terminal hooks now use lookup-only state and ignore a
+  session as soon as its cleanup begins, avoiding post-run map growth and
+  commit/release races. No public package API migration is required.
 
 ## [0.8.4] — 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ are in [`AUDIT.md`](AUDIT.md). This file is the summary index.
 - `dev`: bump `typescript` 6.0.2 → 6.0.3, `vitest` 4.1.2 → 4.1.4,
   `@vitest/coverage-v8` 4.1.2 → 4.1.4, `@types/node` 25.5.0 → 25.6.0.
 
+### Fixed
+
+- Isolated all mutable hook lifecycle state by the OpenClaw session/run scope.
+  Concurrent sessions no longer share pending model holds, active tool
+  reservations, cost totals, caches, call limits, event logs, forecasts, or
+  heartbeat timers. Session cleanup now stops and releases only that session's
+  resources, including commit-error paths. No public API migration is required.
+
 ## [0.8.4] — 2026-05-07
 
 npm metadata refresh for category-search discovery. **No code changes** — bundle and runtime behavior are identical to 0.8.3.

--- a/README.md
+++ b/README.md
@@ -572,7 +572,24 @@ The `costEstimator` receives a context object with `toolName`, `durationMs`, `es
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `userId` | string | — | User ID for budget scoping (can be overridden via `ctx.metadata.userId`) |
-| `sessionId` | string | — | Session ID for budget scoping (can be overridden via `ctx.metadata.sessionId`) |
+| `sessionId` | string | — | Session ID fallback for budget scoping and lifecycle isolation. A host-provided `ctx.sessionId` takes precedence. |
+
+The guard keeps reservations, pending model holds, snapshot caches, cost totals,
+tool-call limits, event logs, forecasts, and heartbeat timers in an isolated
+state for each OpenClaw session. Scope identity is selected in this order:
+host `sessionId`, host `sessionKey` (or legacy `conversationId`), host `runId`,
+configured `sessionId`, host `agentId`, configured/metadata `userId`, then a
+tenant-level unscoped fallback. Direct context fields and legacy
+`ctx.metadata.*` fields are both supported.
+
+Current [OpenClaw agent and tool hook contexts](https://github.com/openclaw/openclaw/blob/main/src/plugins/hook-types.ts)
+provide `sessionId`, `sessionKey`, and `runId`, so normal installations receive
+strong session isolation without configuration. A custom or older host that
+supplies none of the identifiers above cannot be strongly isolated: concurrent
+invocations that reach the same
+agent, user, or final tenant fallback will share state. Configure a unique
+`sessionId` or update the host to pass a session/run identifier before using
+such a host for concurrent multi-tenant enforcement.
 
 ### Session Analytics
 
@@ -964,6 +981,7 @@ Before deploying to production:
 | **Model cost is estimated by default.** OpenClaw has no `after_model_resolve` hook, so model costs are based on `modelBaseCosts` estimates. The `modelCostEstimator` callback can reconcile costs if you have a proxy or gateway with token counts. | Cost tracking for models is approximate unless you provide a `modelCostEstimator`. The plugin will never *overspend* — it may *under-track* slightly. | Use `modelCostEstimator` to reconcile costs. Or buffer `modelBaseCosts` estimates 10–20% higher than expected. |
 | **`ALLOW_WITH_CAPS` decisions are not enforced.** If the Cycles server returns caps (max_tokens, tool allowlist) alongside an ALLOW decision, the plugin stores them but does not apply them downstream. | Low risk — v0 Cycles servers rarely return caps. | Monitor Cycles protocol updates. |
 | **Per-user/session scoping uses custom dimensions.** User and session IDs are passed as `dimensions.user` / `dimensions.session` in the reservation subject. v0 Cycles servers may ignore custom dimensions for balance filtering. | Per-user budget isolation depends on server support for dimensions. | Verify scoping works with your Cycles server version before relying on it in production. |
+| **Lifecycle isolation depends on a host scope identifier.** Current OpenClaw contexts provide `sessionId`, `sessionKey`, and `runId`; custom or older hosts may provide none. | Without any session/run identifier (or configured fallback), concurrent invocations can collapse to agent-, user-, or tenant-scoped best-effort state. | Pass `ctx.sessionId`, `ctx.sessionKey`, or `ctx.runId`; otherwise configure a unique `sessionId` per concurrent session. |
 | **Heartbeat requires client support.** Reservation auto-extension (`heartbeatIntervalMs`) calls `client.extendReservation()`. If the Cycles client does not implement this method, heartbeats are silently skipped. | Long-running tools may still lose cost tracking if the client lacks `extendReservation`. | Use per-tool TTL overrides via `toolReservationTtls` as fallback. |
 | **Model blocking uses a provider-error workaround.** OpenClaw's `before_model_resolve` hook does not support `{ block: true }` ([feature request](https://github.com/openclaw/openclaw/issues/55771)). When budget is exhausted, the plugin overrides the model to `__cycles_budget_exhausted__`, causing the provider to reject the call. The user sees "Unknown model" instead of a clean budget error. | Model calls are effectively blocked, but the error message is a provider error rather than a budget message. Tool blocking via `before_tool_call` works cleanly with `{ block: true }`. | Pending OpenClaw adding `block` support to `before_model_resolve`. |
 | **OpenClaw does not pass model name in hook events.** The `before_model_resolve` event only contains `{ prompt }` — no model name ([feature request](https://github.com/openclaw/openclaw/issues/55771)). The plugin auto-detects the model from system config or falls back to `defaultModelName`. | Model-specific cost tracking requires `defaultModelName` to be set in plugin config. | Set `defaultModelName` to your agent's model (e.g. `"openai/gpt-5-nano"`). |

--- a/README.md
+++ b/README.md
@@ -574,9 +574,12 @@ The `costEstimator` receives a context object with `toolName`, `durationMs`, `es
 | `userId` | string | — | User ID for budget scoping (can be overridden via `ctx.metadata.userId`) |
 | `sessionId` | string | — | Session ID fallback for budget scoping and lifecycle isolation. A host-provided `ctx.sessionId` takes precedence. |
 
-The guard keeps reservations, pending model holds, snapshot caches, cost totals,
-tool-call limits, event logs, forecasts, and heartbeat timers in an isolated
-state for each OpenClaw session. Scope identity is selected in this order:
+Each plugin registration owns an independent Cycles client, configuration,
+logger, metrics emitter, dry-run reservation store, and session-state map. Within
+that runtime, the guard keeps reservations, pending model holds, snapshot
+caches, cost totals, tool-call limits, event logs, forecasts, and heartbeat
+timers in an isolated state for each OpenClaw session. Scope identity is
+selected in this order:
 host `sessionId`, host `sessionKey` (or legacy `conversationId`), host `runId`,
 configured `sessionId`, host `agentId`, configured/metadata `userId`, then a
 tenant-level unscoped fallback. Direct context fields and legacy
@@ -916,7 +919,13 @@ Separately from `failClosed`, the plugin handles **network/transient errors** wi
 }
 ```
 
-Note: commit failures are still fail-open even with this flag — once a reservation is created, the spend has already been committed server-side and local commit retries can't change that. Reservations expire via TTL if commits never reach the server.
+Note: commit failures are still fail-open even with this flag. A successful
+reservation is only a hold; it is not recorded as spend until commit succeeds.
+If a tool commit fails, its heartbeat stops and the hold remains owned by that
+session for release during `agent_end`. A final model commit failure is released
+immediately during `agent_end`. If the control plane is also unavailable for the
+release, the server-side TTL is the final cleanup mechanism and the actual spend
+may remain unreported.
 
 ## Troubleshooting
 
@@ -981,7 +990,7 @@ Before deploying to production:
 | **Model cost is estimated by default.** OpenClaw has no `after_model_resolve` hook, so model costs are based on `modelBaseCosts` estimates. The `modelCostEstimator` callback can reconcile costs if you have a proxy or gateway with token counts. | Cost tracking for models is approximate unless you provide a `modelCostEstimator`. The plugin will never *overspend* — it may *under-track* slightly. | Use `modelCostEstimator` to reconcile costs. Or buffer `modelBaseCosts` estimates 10–20% higher than expected. |
 | **`ALLOW_WITH_CAPS` decisions are not enforced.** If the Cycles server returns caps (max_tokens, tool allowlist) alongside an ALLOW decision, the plugin stores them but does not apply them downstream. | Low risk — v0 Cycles servers rarely return caps. | Monitor Cycles protocol updates. |
 | **Per-user/session scoping uses custom dimensions.** User and session IDs are passed as `dimensions.user` / `dimensions.session` in the reservation subject. v0 Cycles servers may ignore custom dimensions for balance filtering. | Per-user budget isolation depends on server support for dimensions. | Verify scoping works with your Cycles server version before relying on it in production. |
-| **Lifecycle isolation depends on a host scope identifier.** Current OpenClaw contexts provide `sessionId`, `sessionKey`, and `runId`; custom or older hosts may provide none. | Without any session/run identifier (or configured fallback), concurrent invocations can collapse to agent-, user-, or tenant-scoped best-effort state. | Pass `ctx.sessionId`, `ctx.sessionKey`, or `ctx.runId`; otherwise configure a unique `sessionId` per concurrent session. |
+| **Lifecycle isolation within a plugin registration depends on a host scope identifier.** Registrations are always isolated from each other. Current OpenClaw contexts provide `sessionId`, `sessionKey`, and `runId`; custom or older hosts may provide none. | Without any session/run identifier (or configured fallback), concurrent invocations in the same registration can collapse to agent-, user-, or tenant-scoped best-effort state. | Pass `ctx.sessionId`, `ctx.sessionKey`, or `ctx.runId`; otherwise configure a unique `sessionId` per concurrent session. |
 | **Heartbeat requires client support.** Reservation auto-extension (`heartbeatIntervalMs`) calls `client.extendReservation()`. If the Cycles client does not implement this method, heartbeats are silently skipped. | Long-running tools may still lose cost tracking if the client lacks `extendReservation`. | Use per-tool TTL overrides via `toolReservationTtls` as fallback. |
 | **Model blocking uses a provider-error workaround.** OpenClaw's `before_model_resolve` hook does not support `{ block: true }` ([feature request](https://github.com/openclaw/openclaw/issues/55771)). When budget is exhausted, the plugin overrides the model to `__cycles_budget_exhausted__`, causing the provider to reject the call. The user sees "Unknown model" instead of a clean budget error. | Model calls are effectively blocked, but the error message is a provider error rather than a budget message. Tool blocking via `before_tool_call` works cleanly with `{ block: true }`. | Pending OpenClaw adding `block` support to `before_model_resolve`. |
 | **OpenClaw does not pass model name in hook events.** The `before_model_resolve` event only contains `{ prompt }` — no model name ([feature request](https://github.com/openclaw/openclaw/issues/55771)). The plugin auto-detects the model from system config or falls back to `defaultModelName`. | Model-specific cost tracking requires `defaultModelName` to be set in plugin config. | Set `defaultModelName` to your agent's model (e.g. `"openai/gpt-5-nano"`). |

--- a/README.md
+++ b/README.md
@@ -922,10 +922,13 @@ Separately from `failClosed`, the plugin handles **network/transient errors** wi
 Note: commit failures are still fail-open even with this flag. A successful
 reservation is only a hold; it is not recorded as spend until commit succeeds.
 If a tool commit fails, its heartbeat stops and the hold remains owned by that
-session for release during `agent_end`. A final model commit failure is released
-immediately during `agent_end`. If the control plane is also unavailable for the
-release, the server-side TTL is the final cleanup mechanism and the actual spend
-may remain unreported.
+session for release during `agent_end`. A pending model commit failure never
+rejects `before_model_resolve` or `before_prompt_build`: the hold is retained for
+retry, prompt construction continues, and any subsequent model call proceeds
+without creating a second hold while its estimated cost is tracked locally. A
+final model commit failure is released during `agent_end`. If the control plane
+is also unavailable for the release, the server-side TTL is the final cleanup
+mechanism and the actual spend may remain unreported.
 
 ## Troubleshooting
 

--- a/src/cycles.ts
+++ b/src/cycles.ts
@@ -241,7 +241,7 @@ export async function reserveBudget(
 }
 
 // ---------------------------------------------------------------------------
-// Commit (best-effort — never throws)
+// Commit (best-effort — never throws, but reports the outcome)
 // ---------------------------------------------------------------------------
 
 export async function commitUsage(
@@ -251,7 +251,7 @@ export async function commitUsage(
   unit: string,
   logger: OpenClawLogger,
   metrics?: StandardMetrics,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const body: Record<string, unknown> = {
       idempotency_key: randomUUID(),
@@ -265,9 +265,12 @@ export async function commitUsage(
       logger.warn(
         `Commit for reservation ${reservationId} returned status ${response.status}`,
       );
+      return false;
     }
+    return true;
   } catch (err) {
     logger.warn(`Commit failed for reservation ${reservationId}:`, err);
+    return false;
   }
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -71,6 +71,7 @@ interface SessionState {
   /** One pending model hold per isolated session/run. */
   pendingModelReservation?: ActiveReservation;
   pendingModelName?: string;
+  pendingModelTurnIndex?: number;
   turnIndex: number;
   heartbeatTimers: Map<string, ReturnType<typeof setInterval>>;
   eventLog: ReservationLogEntry[];
@@ -79,7 +80,11 @@ interface SessionState {
   lastBurnRate: number;
   exhaustionWarningFired: boolean;
   eventLogCapWarned: boolean;
+  /** Set as soon as agent_end starts so concurrent terminal hooks no-op. */
+  ending: boolean;
 }
+
+type PendingModelCommitOutcome = "none" | "committed" | "deferred";
 
 interface HookRuntime {
   client: CyclesClient;
@@ -179,6 +184,11 @@ export function _resetInitialized(): void {
   if (defaultRuntime) disposeRuntime(defaultRuntime);
   defaultRuntime = undefined;
   defaultHandlers = undefined;
+}
+
+/** @internal Return the legacy runtime's live state count (for testing only). */
+export function _getDefaultSessionStateCount(): number {
+  return defaultRuntime?.sessionStates.size ?? 0;
 }
 
 export function initHooks(
@@ -288,6 +298,7 @@ function createSessionState(
     lastBurnRate: 0,
     exhaustionWarningFired: false,
     eventLogCapWarned: false,
+    ending: false,
   };
 }
 
@@ -306,6 +317,15 @@ function getSessionStateFor(
     state.resolvedSessionId = identity.sessionId ?? state.resolvedSessionId;
   }
   return { key: identity.key, state };
+}
+
+function findSessionStateFor(
+  runtime: HookRuntime,
+  event: Record<string, unknown>,
+  ctx: HookContext,
+): { key: string; state?: SessionState } {
+  const identity = resolveScope(runtime, event, ctx);
+  return { key: identity.key, state: runtime.sessionStates.get(identity.key) };
 }
 
 async function getSnapshotFor(runtime: HookRuntime, state: SessionState): Promise<BudgetSnapshot> {
@@ -588,7 +608,7 @@ function stopAllHeartbeats(state: SessionState): void {
 async function commitPendingModelReservationFor(
   runtime: HookRuntime,
   state: SessionState,
-): Promise<void> {
+): Promise<PendingModelCommitOutcome> {
   const { client, config, logger } = runtime;
   const emitCounter = (name: string, delta: number, tags?: Record<string, string>) =>
     emitCounterFor(runtime, name, delta, tags);
@@ -596,17 +616,18 @@ async function commitPendingModelReservationFor(
     emitHistogramFor(runtime, name, value, tags);
   const logEventForRuntime = (entry: ReservationLogEntry) => logEventFor(runtime, state, entry);
   const getSnapshotForRuntime = () => getSnapshotFor(runtime, state);
-  if (!state.pendingModelReservation) return;
+  if (!state.pendingModelReservation) return "none";
 
   const reservation = state.pendingModelReservation;
   const modelName = state.pendingModelName ?? "unknown";
+  const modelTurnIndex = state.pendingModelTurnIndex ?? state.turnIndex - 1;
   let actual = reservation.estimate;
   if (config.modelCostEstimator) {
     try {
       const computed = config.modelCostEstimator({
         model: modelName,
         estimatedCost: reservation.estimate,
-        turnIndex: state.turnIndex - 1,
+        turnIndex: modelTurnIndex,
       });
       if (computed != null) actual = computed;
     } catch (err) {
@@ -625,10 +646,14 @@ async function commitPendingModelReservationFor(
     metrics,
   );
   if (committed === false) {
-    throw new Error(`Failed to commit model reservation ${reservation.reservationId}`);
+    logger.warn(
+      `Model commit deferred for ${modelName}; retaining reservation ${reservation.reservationId} for retry or agent_end cleanup`,
+    );
+    return "deferred";
   }
   state.pendingModelReservation = undefined;
   state.pendingModelName = undefined;
+  state.pendingModelTurnIndex = undefined;
   logger.info(`Model committed: ${modelName} (cost=${actual} ${unit})`);
 
   trackCost(state, `model:${modelName}`, actual);
@@ -643,6 +668,7 @@ async function commitPendingModelReservationFor(
   if (config.aggressiveCacheInvalidation) {
     await getSnapshotForRuntime();
   }
+  return "committed";
 }
 
 const DEFAULT_TOOL_COST = 100_000;
@@ -671,7 +697,7 @@ async function beforeModelResolveFor(
   // Never create a new hold until the previous model hold for this session has
   // been finalized. A failed commit remains attached to this session so
   // agent_end can release it rather than orphaning either reservation.
-  await commitPendingModelReservationFor(runtime, state);
+  const pendingCommitOutcome = await commitPendingModelReservationFor(runtime, state);
   const snapshot = await getSnapshotFor(runtime, state);
 
   // Resolve model name — check event fields, ctx.metadata, and config fallback.
@@ -757,29 +783,13 @@ async function beforeModelResolveFor(
   const modelCurrency = config.modelCurrency ?? config.currency;
   const actionKind = config.defaultModelActionKind;
 
-  const result = await reserveBudget(client, config, {
-    actionKind,
-    actionName: resolvedModel,
-    estimate: modelCost,
-    unit: modelCurrency,
-    userId: state.resolvedUserId,
-    sessionId: state.resolvedSessionId,
-  });
-
-  if (!isAllowed(result.decision)) {
-    const reason = result.reasonCode ?? "denied";
-    emitCounter("cycles.reservation.denied", 1, { kind: "model", name: resolvedModel, reason });
-    logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "deny", kind: "model", name: resolvedModel, decision: result.decision, reason, budgetLevel: snapshot.level, remaining: snapshot.remaining });
-
-    if (config.failClosed) {
-      logger.warn(`Model reservation denied for ${resolvedModel} (reason: ${reason}, budget: ${snapshot.level}) — blocking model call (failClosed=true)`);
-      return { modelOverride: "__cycles_budget_exhausted__" };
-    }
-    logger.warn(`Model reservation denied for ${resolvedModel} (reason: ${reason}, budget: ${snapshot.level}) — allowing execution to continue (failClosed=false)`);
-
-    // Track cost locally even though no server-side reservation was created.
-    // The model call will proceed, so the session summary and forecasting
-    // should reflect the estimated cost.
+  if (pendingCommitOutcome === "deferred") {
+    // Connectivity failures are fail-open, but the prior hold must not be
+    // overwritten. Allow this call without a second server-side reservation
+    // and account for its estimate locally until the session ends.
+    logger.warn(
+      `Allowing model ${resolvedModel} without a new reservation because the previous model commit is deferred`,
+    );
     trackCost(state, `model:${resolvedModel}`, modelCost);
     state.totalModelCost += modelCost;
     state.totalModelCalls++;
@@ -788,44 +798,81 @@ async function beforeModelResolveFor(
       state.remainingCallsAllowed--;
     }
     invalidateSnapshotCache(state);
-
-    logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: result.decision, reason: `${reason}:allowed_without_reservation`, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+    logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: "ALLOW", reason: "pending_commit_deferred:allowed_without_reservation", budgetLevel: snapshot.level, remaining: snapshot.remaining });
     checkBurnRate(state, snapshot.remaining);
     checkExhaustionForecast(state, snapshot.remaining);
   } else {
-    state.totalReservationsMade++;
-    emitCounter("cycles.reservation.created", 1, { kind: "model", name: resolvedModel });
-    logger.info(`Model reserved: ${resolvedModel} (estimate=${modelCost}, remaining=${snapshot.remaining})`);
+    const result = await reserveBudget(client, config, {
+      actionKind,
+      actionName: resolvedModel,
+      estimate: modelCost,
+      unit: modelCurrency,
+      userId: state.resolvedUserId,
+      sessionId: state.resolvedSessionId,
+    });
 
-    if (result.reservationId) {
-      // v0.5.0: Reserve-then-commit pattern — hold the reservation open.
-      // It will be committed in the next beforePromptBuild or at agentEnd,
-      // allowing modelCostEstimator to reconcile the cost.
-      state.pendingModelReservation = {
-        reservationId: result.reservationId,
-        estimate: modelCost,
-        toolName: resolvedModel,
-        createdAt: Date.now(),
-        kind: "model",
-        currency: modelCurrency,
-      };
-      state.pendingModelName = resolvedModel;
-    } else {
-      // No reservation ID (e.g. dry-run with DENY) — track immediately
+    if (!isAllowed(result.decision)) {
+      const reason = result.reasonCode ?? "denied";
+      emitCounter("cycles.reservation.denied", 1, { kind: "model", name: resolvedModel, reason });
+      logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "deny", kind: "model", name: resolvedModel, decision: result.decision, reason, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+
+      if (config.failClosed) {
+        logger.warn(`Model reservation denied for ${resolvedModel} (reason: ${reason}, budget: ${snapshot.level}) — blocking model call (failClosed=true)`);
+        return { modelOverride: "__cycles_budget_exhausted__" };
+      }
+      logger.warn(`Model reservation denied for ${resolvedModel} (reason: ${reason}, budget: ${snapshot.level}) — allowing execution to continue (failClosed=false)`);
+
+      // Track cost locally even though no server-side reservation was created.
+      // The model call will proceed, so the session summary and forecasting
+      // should reflect the estimated cost.
       trackCost(state, `model:${resolvedModel}`, modelCost);
       state.totalModelCost += modelCost;
       state.totalModelCalls++;
-    }
+      state.turnIndex++;
+      if (snapshot.level === "low" && config.lowBudgetStrategies.includes("limit_remaining_calls")) {
+        state.remainingCallsAllowed--;
+      }
+      invalidateSnapshotCache(state);
 
-    state.turnIndex++;
-    if (snapshot.level === "low" && config.lowBudgetStrategies.includes("limit_remaining_calls")) {
-      state.remainingCallsAllowed--;
-    }
-    invalidateSnapshotCache(state);
+      logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: result.decision, reason: `${reason}:allowed_without_reservation`, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+      checkBurnRate(state, snapshot.remaining);
+      checkExhaustionForecast(state, snapshot.remaining);
+    } else {
+      state.totalReservationsMade++;
+      emitCounter("cycles.reservation.created", 1, { kind: "model", name: resolvedModel });
+      logger.info(`Model reserved: ${resolvedModel} (estimate=${modelCost}, remaining=${snapshot.remaining})`);
 
-    logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: result.decision, budgetLevel: snapshot.level, remaining: snapshot.remaining });
-    checkBurnRate(state, snapshot.remaining);
-    checkExhaustionForecast(state, snapshot.remaining);
+      if (result.reservationId) {
+        // v0.5.0: Reserve-then-commit pattern — hold the reservation open.
+        // It will be committed in the next beforePromptBuild or at agentEnd,
+        // allowing modelCostEstimator to reconcile the cost.
+        state.pendingModelReservation = {
+          reservationId: result.reservationId,
+          estimate: modelCost,
+          toolName: resolvedModel,
+          createdAt: Date.now(),
+          kind: "model",
+          currency: modelCurrency,
+        };
+        state.pendingModelName = resolvedModel;
+        state.pendingModelTurnIndex = state.turnIndex;
+      } else {
+        // No reservation ID (e.g. dry-run with DENY) — track immediately
+        trackCost(state, `model:${resolvedModel}`, modelCost);
+        state.totalModelCost += modelCost;
+        state.totalModelCalls++;
+      }
+
+      state.turnIndex++;
+      if (snapshot.level === "low" && config.lowBudgetStrategies.includes("limit_remaining_calls")) {
+        state.remainingCallsAllowed--;
+      }
+      invalidateSnapshotCache(state);
+
+      logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: result.decision, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+      checkBurnRate(state, snapshot.remaining);
+      checkExhaustionForecast(state, snapshot.remaining);
+    }
   }
 
   if (resolvedModel !== eventModel) {
@@ -1115,7 +1162,13 @@ async function afterToolCallFor(
     emitHistogramFor(runtime, name, value, tags);
   const logEvent = (state: SessionState, entry: ReservationLogEntry) =>
     logEventFor(runtime, state, entry);
-  const { state } = getSessionStateFor(runtime, event, ctx);
+  const { state } = findSessionStateFor(runtime, event, ctx);
+  if (!state || state.ending) {
+    logger.debug(
+      `after_tool_call: session state is absent or ending for callId=${event.toolCallId}`,
+    );
+    return;
+  }
   const reservation = state.activeReservations.get(event.toolCallId);
   if (!reservation) {
     logger.debug(
@@ -1195,15 +1248,22 @@ async function agentEndFor(
   const logEvent = (state: SessionState, entry: ReservationLogEntry) =>
     logEventFor(runtime, state, entry);
   const { key, state } = getSessionStateFor(runtime, event, ctx);
+  state.ending = true;
   try {
     // v0.5.0: Commit any pending model reservation from the last turn.
     // If commit fails, release the reservation so budget isn't locked until TTL.
     if (state.pendingModelReservation) {
       const resId = state.pendingModelReservation.reservationId;
       try {
-        await commitPendingModelReservationFor(runtime, state);
+        const outcome = await commitPendingModelReservationFor(runtime, state);
+        if (outcome === "deferred") {
+          logger.warn(
+            `Failed to commit pending model reservation ${resId} at agent_end, releasing`,
+          );
+          await releaseReservation(client, resId, "commit_failed_at_agent_end", logger);
+        }
       } catch (err) {
-        logger.warn(`Failed to commit pending model reservation ${resId} at agent_end, releasing:`, err);
+        logger.warn(`Unexpected error committing pending model reservation ${resId} at agent_end, releasing:`, err);
         await releaseReservation(client, resId, "commit_failed_at_agent_end", logger);
       }
     }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,9 +2,9 @@
  * OpenClaw lifecycle hook implementations.
  *
  * All hooks follow the OpenClaw (event, ctx) => result pattern.
- * Mutable lifecycle state is isolated by the session/run identity supplied by
- * OpenClaw. Module-level values are limited to plugin runtime dependencies and
- * the map that owns those isolated states.
+ * Mutable lifecycle state is isolated first by plugin registration, then by
+ * the session/run identity supplied by OpenClaw. Each registered handler set
+ * closes over its own client, config, logger, metrics, and session state map.
  */
 
 import { type CyclesClient, isAllowed } from "runcycles";
@@ -50,10 +50,6 @@ import { DryRunClient } from "./dry-run.js";
 // Plugin runtime and isolated session state
 // ---------------------------------------------------------------------------
 
-let client: CyclesClient;
-let config: BudgetGuardConfig;
-let logger: OpenClawLogger;
-
 interface SessionState {
   /** In-flight tool reservations keyed by the host's toolCallId. */
   activeReservations: Map<string, ActiveReservation>;
@@ -85,62 +81,124 @@ interface SessionState {
   eventLogCapWarned: boolean;
 }
 
-/** All mutable hook lifecycle state, keyed by a stable OpenClaw scope. */
-const sessionStates = new Map<string, SessionState>();
+interface HookRuntime {
+  client: CyclesClient;
+  config: BudgetGuardConfig;
+  logger: OpenClawLogger;
+  /** All mutable lifecycle state for this registration, keyed by host scope. */
+  sessionStates: Map<string, SessionState>;
+  metricsEmitter?: MetricsEmitter;
+  baseTags: Record<string, string>;
+}
 
-/** v0.5.0: Metrics emitter reference (from config or OTLP auto-creation). */
-let metricsEmitter: MetricsEmitter | undefined;
-
-/** v0.5.0: Base tags for all metrics. */
-let baseTags: Record<string, string> = {};
+export interface HookHandlers {
+  beforeModelResolve: (
+    event: ModelResolveEvent,
+    ctx: HookContext,
+  ) => Promise<ModelResolveResult | undefined>;
+  beforePromptBuild: (
+    event: PromptBuildEvent,
+    ctx: HookContext,
+  ) => Promise<PromptBuildResult | undefined>;
+  beforeToolCall: (
+    event: ToolCallEvent,
+    ctx: HookContext,
+  ) => Promise<ToolCallResult | undefined>;
+  afterToolCall: (event: ToolResultEvent, ctx: HookContext) => Promise<void>;
+  agentEnd: (event: AgentEndEvent, ctx: HookContext) => Promise<void>;
+}
 
 // ---------------------------------------------------------------------------
 // Initialization
 // ---------------------------------------------------------------------------
 
-/** Tracks whether initHooks has been called at least once this session. */
-let initialized = false;
+let defaultRuntime: HookRuntime | undefined;
+let defaultHandlers: HookHandlers | undefined;
+
+function createRuntime(
+  pluginConfig: BudgetGuardConfig,
+  apiLogger?: OpenClawLogger,
+): HookRuntime {
+  const runtimeLogger = apiLogger ?? createLogger(pluginConfig.logLevel);
+  let runtimeClient: CyclesClient;
+
+  if (pluginConfig.dryRun) {
+    runtimeClient = new DryRunClient(
+      pluginConfig.dryRunBudget,
+      pluginConfig.currency,
+    ) as unknown as CyclesClient;
+    runtimeLogger.info(
+      `[DRY-RUN] Simulated budget=${pluginConfig.dryRunBudget} ${pluginConfig.currency}`,
+    );
+  } else {
+    runtimeClient = createCyclesClient(pluginConfig);
+  }
+
+  const runtimeBaseTags: Record<string, string> = { tenant: pluginConfig.tenant };
+  if (pluginConfig.budgetScope) {
+    for (const [key, value] of Object.entries(pluginConfig.budgetScope)) {
+      runtimeBaseTags[key] = value;
+    }
+  }
+
+  return {
+    client: runtimeClient,
+    config: pluginConfig,
+    logger: runtimeLogger,
+    sessionStates: new Map(),
+    metricsEmitter: pluginConfig.metricsEmitter,
+    baseTags: runtimeBaseTags,
+  };
+}
+
+function createHandlers(runtime: HookRuntime): HookHandlers {
+  return {
+    beforeModelResolve: (event, ctx) => beforeModelResolveFor(runtime, event, ctx),
+    beforePromptBuild: (event, ctx) => beforePromptBuildFor(runtime, event, ctx),
+    beforeToolCall: (event, ctx) => beforeToolCallFor(runtime, event, ctx),
+    afterToolCall: (event, ctx) => afterToolCallFor(runtime, event, ctx),
+    agentEnd: (event, ctx) => agentEndFor(runtime, event, ctx),
+  };
+}
+
+function disposeRuntime(runtime: HookRuntime): void {
+  for (const state of runtime.sessionStates.values()) stopAllHeartbeats(state);
+  runtime.sessionStates.clear();
+}
+
+/** Create a fully isolated handler set for one OpenClaw plugin registration. */
+export function createHooks(
+  pluginConfig: BudgetGuardConfig,
+  apiLogger?: OpenClawLogger,
+): HookHandlers {
+  return createHandlers(createRuntime(pluginConfig, apiLogger));
+}
 
 /** @internal Reset initialization flag (for testing only). */
 export function _resetInitialized(): void {
-  initialized = false;
+  if (defaultRuntime) disposeRuntime(defaultRuntime);
+  defaultRuntime = undefined;
+  defaultHandlers = undefined;
 }
 
 export function initHooks(
   pluginConfig: BudgetGuardConfig,
   apiLogger?: OpenClawLogger,
-): void {
-  config = pluginConfig;
-  logger = apiLogger ?? createLogger(config.logLevel);
-
-  // Gap 10: Dry-run mode
-  if (config.dryRun) {
-    client = new DryRunClient(config.dryRunBudget, config.currency) as unknown as CyclesClient;
-    logger.info(`[DRY-RUN] Simulated budget=${config.dryRunBudget} ${config.currency}`);
-  } else {
-    client = createCyclesClient(config);
+): HookHandlers {
+  // Legacy direct-hook users share one intentionally stable default runtime.
+  // Production registrations use createHooks() and never touch this singleton.
+  if (!defaultHandlers) {
+    defaultRuntime = createRuntime(pluginConfig, apiLogger);
+    defaultHandlers = createHandlers(defaultRuntime);
   }
+  return defaultHandlers;
+}
 
-  // v0.5.0: Set up metrics emitter
-  metricsEmitter = config.metricsEmitter;
-  baseTags = { tenant: config.tenant };
-  if (config.budgetScope) {
-    for (const [key, value] of Object.entries(config.budgetScope)) {
-      baseTags[key] = value;
-    }
+function requireDefaultHandlers(): HookHandlers {
+  if (!defaultHandlers) {
+    throw new Error("initHooks must be called before invoking exported hook functions");
   }
-
-  // OpenClaw calls the plugin entrypoint (and thus initHooks) multiple times —
-  // once per channel/worker. Only reset isolated states on the first init.
-  // Subsequent inits update config/client/logger while preserving each
-  // session's own counters and reservations.
-  if (initialized) {
-    return;
-  }
-  initialized = true;
-
-  for (const state of sessionStates.values()) stopAllHeartbeats(state);
-  sessionStates.clear();
+  return defaultHandlers;
 }
 
 // ---------------------------------------------------------------------------
@@ -152,9 +210,11 @@ function asNonEmptyString(value: unknown): string | undefined {
 }
 
 function resolveScope(
+  runtime: HookRuntime,
   event: Record<string, unknown>,
   ctx: HookContext,
 ): { key: string; userId?: string; sessionId?: string } {
+  const { config } = runtime;
   const metadata = ctx.metadata ?? {};
   const scopeKey = (kind: string, id: string) => JSON.stringify([config.tenant, kind, id]);
   const userId = asNonEmptyString(metadata.userId) ?? config.userId;
@@ -199,7 +259,11 @@ function resolveScope(
   return { key: scopeKey("unscoped", "default"), sessionId: config.sessionId };
 }
 
-function createSessionState(identity: { userId?: string; sessionId?: string }): SessionState {
+function createSessionState(
+  runtime: HookRuntime,
+  identity: { userId?: string; sessionId?: string },
+): SessionState {
+  const { config } = runtime;
   const now = Date.now();
   return {
     activeReservations: new Map(),
@@ -227,15 +291,16 @@ function createSessionState(identity: { userId?: string; sessionId?: string }): 
   };
 }
 
-function getSessionState(
+function getSessionStateFor(
+  runtime: HookRuntime,
   event: Record<string, unknown>,
   ctx: HookContext,
 ): { key: string; state: SessionState } {
-  const identity = resolveScope(event, ctx);
-  let state = sessionStates.get(identity.key);
+  const identity = resolveScope(runtime, event, ctx);
+  let state = runtime.sessionStates.get(identity.key);
   if (!state) {
-    state = createSessionState(identity);
-    sessionStates.set(identity.key, state);
+    state = createSessionState(runtime, identity);
+    runtime.sessionStates.set(identity.key, state);
   } else {
     state.resolvedUserId = identity.userId ?? state.resolvedUserId;
     state.resolvedSessionId = identity.sessionId ?? state.resolvedSessionId;
@@ -243,7 +308,10 @@ function getSessionState(
   return { key: identity.key, state };
 }
 
-async function getSnapshot(state: SessionState): Promise<BudgetSnapshot> {
+async function getSnapshotFor(runtime: HookRuntime, state: SessionState): Promise<BudgetSnapshot> {
+  const { client, config, logger } = runtime;
+  const emitGauge = (name: string, value: number, tags?: Record<string, string>) =>
+    emitGaugeFor(runtime, name, value, tags);
   const now = Date.now();
   if (state.cachedSnapshot && now - state.cachedSnapshotAt < config.snapshotCacheTtlMs) {
     return state.cachedSnapshot;
@@ -290,7 +358,7 @@ async function getSnapshot(state: SessionState): Promise<BudgetSnapshot> {
       logger.warn("onBudgetTransition callback error:", err);
     }
     if (config.budgetTransitionWebhookUrl) {
-      fireWebhook(config.budgetTransitionWebhookUrl, event);
+      fireWebhookFor(runtime, config.budgetTransitionWebhookUrl, event);
     }
   }
   state.lastKnownLevel = state.cachedSnapshot.level;
@@ -347,14 +415,14 @@ function buildForecast(state: SessionState): ForecastData {
 }
 
 /** Fire a webhook POST (best-effort, non-blocking). */
-function fireWebhook(url: string, payload: unknown): void {
+function fireWebhookFor(runtime: HookRuntime, url: string, payload: unknown): void {
   fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
     signal: AbortSignal.timeout(10_000),
   }).catch((err) => {
-    logger.warn(`Webhook POST to ${url} failed:`, err);
+    runtime.logger.warn(`Webhook POST to ${url} failed:`, err);
   });
 }
 
@@ -364,23 +432,24 @@ function sleep(ms: number): Promise<void> {
 }
 
 /** v0.5.0: Safe metrics emission (never throws). */
-function emitGauge(name: string, value: number, tags?: Record<string, string>): void {
-  if (!metricsEmitter) return;
-  try { metricsEmitter.gauge(name, value, { ...baseTags, ...tags }); } catch { /* best-effort */ }
+function emitGaugeFor(runtime: HookRuntime, name: string, value: number, tags?: Record<string, string>): void {
+  if (!runtime.metricsEmitter) return;
+  try { runtime.metricsEmitter.gauge(name, value, { ...runtime.baseTags, ...tags }); } catch { /* best-effort */ }
 }
-function emitCounter(name: string, delta: number, tags?: Record<string, string>): void {
-  if (!metricsEmitter) return;
-  try { metricsEmitter.counter(name, delta, { ...baseTags, ...tags }); } catch { /* best-effort */ }
+function emitCounterFor(runtime: HookRuntime, name: string, delta: number, tags?: Record<string, string>): void {
+  if (!runtime.metricsEmitter) return;
+  try { runtime.metricsEmitter.counter(name, delta, { ...runtime.baseTags, ...tags }); } catch { /* best-effort */ }
 }
-function emitHistogram(name: string, value: number, tags?: Record<string, string>): void {
-  if (!metricsEmitter) return;
-  try { metricsEmitter.histogram(name, value, { ...baseTags, ...tags }); } catch { /* best-effort */ }
+function emitHistogramFor(runtime: HookRuntime, name: string, value: number, tags?: Record<string, string>): void {
+  if (!runtime.metricsEmitter) return;
+  try { runtime.metricsEmitter.histogram(name, value, { ...runtime.baseTags, ...tags }); } catch { /* best-effort */ }
 }
 
 const MAX_EVENT_LOG_ENTRIES = 10_000;
 
 /** v0.6.0: Append to event log if enabled. Capped to prevent unbounded growth. */
-function logEvent(state: SessionState, entry: ReservationLogEntry): void {
+function logEventFor(runtime: HookRuntime, state: SessionState, entry: ReservationLogEntry): void {
+  const { config, logger } = runtime;
   if (!config.enableEventLog) return;
   if (state.eventLog.length >= MAX_EVENT_LOG_ENTRIES) {
     if (!state.eventLogCapWarned) {
@@ -400,7 +469,10 @@ function sessionCostTotal(state: SessionState): number {
 }
 
 /** v0.6.0: Check burn rate and fire anomaly if needed. */
-function checkBurnRate(state: SessionState, remaining: number): void {
+function checkBurnRateFor(runtime: HookRuntime, state: SessionState, remaining: number): void {
+  const { config, logger } = runtime;
+  const emitCounter = (name: string, delta: number, tags?: Record<string, string>) =>
+    emitCounterFor(runtime, name, delta, tags);
   const now = Date.now();
   const elapsed = now - state.windowStartedAt;
   if (elapsed < config.burnRateWindowMs || elapsed <= 0) return;
@@ -435,7 +507,10 @@ function checkBurnRate(state: SessionState, remaining: number): void {
 }
 
 /** v0.6.0: Check if budget will exhaust soon and warn. */
-function checkExhaustionForecast(state: SessionState, remaining: number): void {
+function checkExhaustionForecastFor(runtime: HookRuntime, state: SessionState, remaining: number): void {
+  const { config, logger } = runtime;
+  const emitGauge = (name: string, value: number, tags?: Record<string, string>) =>
+    emitGaugeFor(runtime, name, value, tags);
   if (state.exhaustionWarningFired || remaining === Infinity) return;
   const elapsed = Date.now() - state.sessionStartedAt;
   if (elapsed < 1000) return; // need at least 1s of data
@@ -464,7 +539,13 @@ function checkExhaustionForecast(state: SessionState, remaining: number): void {
 }
 
 /** v0.6.0: Start heartbeat timer for a tool reservation. */
-function startHeartbeat(state: SessionState, toolCallId: string, reservationId: string): void {
+function startHeartbeatFor(
+  runtime: HookRuntime,
+  state: SessionState,
+  toolCallId: string,
+  reservationId: string,
+): void {
+  const { client, config, logger } = runtime;
   if (config.heartbeatIntervalMs <= 0) return;
   const heartbeatClient = client;
   const heartbeatIntervalMs = config.heartbeatIntervalMs;
@@ -504,14 +585,21 @@ function stopAllHeartbeats(state: SessionState): void {
 }
 
 /** v0.5.0: Commit pending model reservation from previous turn. */
-async function commitPendingModelReservation(state: SessionState): Promise<void> {
+async function commitPendingModelReservationFor(
+  runtime: HookRuntime,
+  state: SessionState,
+): Promise<void> {
+  const { client, config, logger } = runtime;
+  const emitCounter = (name: string, delta: number, tags?: Record<string, string>) =>
+    emitCounterFor(runtime, name, delta, tags);
+  const emitHistogram = (name: string, value: number, tags?: Record<string, string>) =>
+    emitHistogramFor(runtime, name, value, tags);
+  const logEventForRuntime = (entry: ReservationLogEntry) => logEventFor(runtime, state, entry);
+  const getSnapshotForRuntime = () => getSnapshotFor(runtime, state);
   if (!state.pendingModelReservation) return;
 
   const reservation = state.pendingModelReservation;
   const modelName = state.pendingModelName ?? "unknown";
-  state.pendingModelReservation = undefined;
-  state.pendingModelName = undefined;
-
   let actual = reservation.estimate;
   if (config.modelCostEstimator) {
     try {
@@ -528,7 +616,19 @@ async function commitPendingModelReservation(state: SessionState): Promise<void>
 
   const unit = reservation.currency ?? config.currency;
   const metrics: StandardMetrics = { model_version: modelName };
-  await commitUsage(client, reservation.reservationId, actual, unit, logger, metrics);
+  const committed = await commitUsage(
+    client,
+    reservation.reservationId,
+    actual,
+    unit,
+    logger,
+    metrics,
+  );
+  if (committed === false) {
+    throw new Error(`Failed to commit model reservation ${reservation.reservationId}`);
+  }
+  state.pendingModelReservation = undefined;
+  state.pendingModelName = undefined;
   logger.info(`Model committed: ${modelName} (cost=${actual} ${unit})`);
 
   trackCost(state, `model:${modelName}`, actual);
@@ -537,11 +637,11 @@ async function commitPendingModelReservation(state: SessionState): Promise<void>
 
   emitCounter("cycles.reservation.committed", 1, { kind: "model", name: modelName });
   emitHistogram("cycles.reservation.cost", actual, { kind: "model", name: modelName });
-  logEvent(state, { timestamp: Date.now(), hook: "commit_model", action: "commit", kind: "model", name: modelName, amount: actual, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
+  logEventForRuntime({ timestamp: Date.now(), hook: "commit_model", action: "commit", kind: "model", name: modelName, amount: actual, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
 
   invalidateSnapshotCache(state);
   if (config.aggressiveCacheInvalidation) {
-    await getSnapshot(state);
+    await getSnapshotForRuntime();
   }
 }
 
@@ -552,12 +652,27 @@ const DEFAULT_MODEL_COST = 500_000;
 // Hook: before_model_resolve
 // ---------------------------------------------------------------------------
 
-export async function beforeModelResolve(
+async function beforeModelResolveFor(
+  runtime: HookRuntime,
   event: ModelResolveEvent,
   ctx: HookContext,
 ): Promise<ModelResolveResult | undefined> {
-  const { state } = getSessionState(event, ctx);
-  const snapshot = await getSnapshot(state);
+  const { client, config, logger } = runtime;
+  const emitCounter = (name: string, delta: number, tags?: Record<string, string>) =>
+    emitCounterFor(runtime, name, delta, tags);
+  const logEvent = (state: SessionState, entry: ReservationLogEntry) =>
+    logEventFor(runtime, state, entry);
+  const checkBurnRate = (state: SessionState, remaining: number) =>
+    checkBurnRateFor(runtime, state, remaining);
+  const checkExhaustionForecast = (state: SessionState, remaining: number) =>
+    checkExhaustionForecastFor(runtime, state, remaining);
+  const { state } = getSessionStateFor(runtime, event, ctx);
+
+  // Never create a new hold until the previous model hold for this session has
+  // been finalized. A failed commit remains attached to this session so
+  // agent_end can release it rather than orphaning either reservation.
+  await commitPendingModelReservationFor(runtime, state);
+  const snapshot = await getSnapshotFor(runtime, state);
 
   // Resolve model name — check event fields, ctx.metadata, and config fallback.
   // OpenClaw may pass the model in different places depending on version.
@@ -682,9 +797,6 @@ export async function beforeModelResolve(
     emitCounter("cycles.reservation.created", 1, { kind: "model", name: resolvedModel });
     logger.info(`Model reserved: ${resolvedModel} (estimate=${modelCost}, remaining=${snapshot.remaining})`);
 
-    // v0.5.0: Commit any pending model reservation from previous turn first
-    await commitPendingModelReservation(state);
-
     if (result.reservationId) {
       // v0.5.0: Reserve-then-commit pattern — hold the reservation open.
       // It will be committed in the next beforePromptBuild or at agentEnd,
@@ -732,17 +844,19 @@ export async function beforeModelResolve(
 // Hook: before_prompt_build
 // ---------------------------------------------------------------------------
 
-export async function beforePromptBuild(
+async function beforePromptBuildFor(
+  runtime: HookRuntime,
   event: PromptBuildEvent,
   ctx: HookContext,
 ): Promise<PromptBuildResult | undefined> {
-  const { state } = getSessionState(event, ctx);
+  const { config, logger } = runtime;
+  const { state } = getSessionStateFor(runtime, event, ctx);
   // v0.5.0: Commit pending model reservation from previous turn
-  await commitPendingModelReservation(state);
+  await commitPendingModelReservationFor(runtime, state);
 
   if (!config.injectPromptBudgetHint) return undefined;
 
-  const snapshot = await getSnapshot(state);
+  const snapshot = await getSnapshotFor(runtime, state);
 
   // Gap 12: Attach status
   attachBudgetStatus(ctx, snapshot);
@@ -771,10 +885,22 @@ export async function beforePromptBuild(
 // Hook: before_tool_call
 // ---------------------------------------------------------------------------
 
-export async function beforeToolCall(
+async function beforeToolCallFor(
+  runtime: HookRuntime,
   event: ToolCallEvent,
   ctx: HookContext,
 ): Promise<ToolCallResult | undefined> {
+  const { client, config, logger } = runtime;
+  const emitCounter = (name: string, delta: number, tags?: Record<string, string>) =>
+    emitCounterFor(runtime, name, delta, tags);
+  const logEvent = (state: SessionState, entry: ReservationLogEntry) =>
+    logEventFor(runtime, state, entry);
+  const startHeartbeat = (state: SessionState, toolCallId: string, reservationId: string) =>
+    startHeartbeatFor(runtime, state, toolCallId, reservationId);
+  const checkBurnRate = (state: SessionState, remaining: number) =>
+    checkBurnRateFor(runtime, state, remaining);
+  const checkExhaustionForecast = (state: SessionState, remaining: number) =>
+    checkExhaustionForecastFor(runtime, state, remaining);
   const toolName = event.toolName;
 
   // Guard against missing event fields
@@ -787,7 +913,7 @@ export async function beforeToolCall(
     return { block: true, blockReason: "Missing tool call ID in event" };
   }
 
-  const { state } = getSessionState(event, ctx);
+  const { state } = getSessionStateFor(runtime, event, ctx);
 
   // Gap 7: Check tool allowlist/blocklist
   const permission = isToolPermitted(toolName, config.toolAllowlist, config.toolBlocklist);
@@ -816,7 +942,7 @@ export async function beforeToolCall(
   }
 
   // Gap 12: Attach budget status
-  const snapshot = await getSnapshot(state);
+  const snapshot = await getSnapshotFor(runtime, state);
   attachBudgetStatus(ctx, snapshot);
 
   // Log once per tool when using default cost estimate
@@ -977,11 +1103,19 @@ export async function beforeToolCall(
 // Hook: after_tool_call
 // ---------------------------------------------------------------------------
 
-export async function afterToolCall(
+async function afterToolCallFor(
+  runtime: HookRuntime,
   event: ToolResultEvent,
   ctx: HookContext,
 ): Promise<void> {
-  const { state } = getSessionState(event, ctx);
+  const { client, config, logger } = runtime;
+  const emitCounter = (name: string, delta: number, tags?: Record<string, string>) =>
+    emitCounterFor(runtime, name, delta, tags);
+  const emitHistogram = (name: string, value: number, tags?: Record<string, string>) =>
+    emitHistogramFor(runtime, name, value, tags);
+  const logEvent = (state: SessionState, entry: ReservationLogEntry) =>
+    logEventFor(runtime, state, entry);
+  const { state } = getSessionStateFor(runtime, event, ctx);
   const reservation = state.activeReservations.get(event.toolCallId);
   if (!reservation) {
     logger.debug(
@@ -1009,7 +1143,19 @@ export async function afterToolCall(
   }
 
   const unit = reservation.currency ?? config.currency;
-  await commitUsage(client, reservation.reservationId, actual, unit, logger);
+  const committed = await commitUsage(
+    client,
+    reservation.reservationId,
+    actual,
+    unit,
+    logger,
+  );
+  if (committed === false) {
+    logger.warn(
+      `Tool commit failed for ${reservation.toolName}; retaining reservation for agent_end cleanup`,
+    );
+    return;
+  }
   // Delete from tracking AFTER commit (not before) so orphaned reservations
   // can be released at agentEnd if commit fails
   state.activeReservations.delete(event.toolCallId);
@@ -1030,7 +1176,7 @@ export async function afterToolCall(
 
   // v0.5.0: Aggressive cache invalidation — proactively refetch after mutation
   if (config.aggressiveCacheInvalidation) {
-    await getSnapshot(state);
+    await getSnapshotFor(runtime, state);
   }
 }
 
@@ -1038,18 +1184,24 @@ export async function afterToolCall(
 // Hook: agent_end
 // ---------------------------------------------------------------------------
 
-export async function agentEnd(
+async function agentEndFor(
+  runtime: HookRuntime,
   event: AgentEndEvent,
   ctx: HookContext,
 ): Promise<void> {
-  const { key, state } = getSessionState(event, ctx);
+  const { client, config, logger } = runtime;
+  const emitHistogram = (name: string, value: number, tags?: Record<string, string>) =>
+    emitHistogramFor(runtime, name, value, tags);
+  const logEvent = (state: SessionState, entry: ReservationLogEntry) =>
+    logEventFor(runtime, state, entry);
+  const { key, state } = getSessionStateFor(runtime, event, ctx);
   try {
     // v0.5.0: Commit any pending model reservation from the last turn.
     // If commit fails, release the reservation so budget isn't locked until TTL.
     if (state.pendingModelReservation) {
       const resId = state.pendingModelReservation.reservationId;
       try {
-        await commitPendingModelReservation(state);
+        await commitPendingModelReservationFor(runtime, state);
       } catch (err) {
         logger.warn(`Failed to commit pending model reservation ${resId} at agent_end, releasing:`, err);
         await releaseReservation(client, resId, "commit_failed_at_agent_end", logger);
@@ -1077,7 +1229,7 @@ export async function agentEnd(
 
     // Fetch final budget state for summary
     invalidateSnapshotCache(state);
-    const snapshot = await getSnapshot(state);
+    const snapshot = await getSnapshotFor(runtime, state);
 
     // Gap 6: Build cost breakdown as plain object
     const breakdown: Record<string, { count: number; totalCost: number }> = {};
@@ -1145,7 +1297,7 @@ export async function agentEnd(
       }
     }
     if (config.analyticsWebhookUrl) {
-      fireWebhook(config.analyticsWebhookUrl, summary);
+      fireWebhookFor(runtime, config.analyticsWebhookUrl, summary);
     }
 
     // v0.5.0: Emit session-level metrics
@@ -1155,9 +1307,9 @@ export async function agentEnd(
     emitHistogram("cycles.session.total_cost", totalCost);
 
     // v0.7.10: Flush metrics emitter to ensure all datapoints are sent
-    if (metricsEmitter?.flush) {
+    if (runtime.metricsEmitter?.flush) {
       try {
-        await metricsEmitter.flush();
+        await runtime.metricsEmitter.flush();
       } catch {
         // Best-effort — metrics flush failure is non-fatal
       }
@@ -1166,6 +1318,45 @@ export async function agentEnd(
     // Never allow a timer or completed session state to survive agent_end,
     // including callback, metrics, snapshot, commit, or release error paths.
     stopAllHeartbeats(state);
-    if (sessionStates.get(key) === state) sessionStates.delete(key);
+    if (runtime.sessionStates.get(key) === state) runtime.sessionStates.delete(key);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compatible direct hook exports
+// ---------------------------------------------------------------------------
+
+export async function beforeModelResolve(
+  event: ModelResolveEvent,
+  ctx: HookContext,
+): Promise<ModelResolveResult | undefined> {
+  return requireDefaultHandlers().beforeModelResolve(event, ctx);
+}
+
+export async function beforePromptBuild(
+  event: PromptBuildEvent,
+  ctx: HookContext,
+): Promise<PromptBuildResult | undefined> {
+  return requireDefaultHandlers().beforePromptBuild(event, ctx);
+}
+
+export async function beforeToolCall(
+  event: ToolCallEvent,
+  ctx: HookContext,
+): Promise<ToolCallResult | undefined> {
+  return requireDefaultHandlers().beforeToolCall(event, ctx);
+}
+
+export async function afterToolCall(
+  event: ToolResultEvent,
+  ctx: HookContext,
+): Promise<void> {
+  return requireDefaultHandlers().afterToolCall(event, ctx);
+}
+
+export async function agentEnd(
+  event: AgentEndEvent,
+  ctx: HookContext,
+): Promise<void> {
+  return requireDefaultHandlers().agentEnd(event, ctx);
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,7 +2,9 @@
  * OpenClaw lifecycle hook implementations.
  *
  * All hooks follow the OpenClaw (event, ctx) => result pattern.
- * Module-level state is initialized once via initHooks().
+ * Mutable lifecycle state is isolated by the session/run identity supplied by
+ * OpenClaw. Module-level values are limited to plugin runtime dependencies and
+ * the map that owns those isolated states.
  */
 
 import { type CyclesClient, isAllowed } from "runcycles";
@@ -45,77 +47,52 @@ import { createLogger } from "./logger.js";
 import { DryRunClient } from "./dry-run.js";
 
 // ---------------------------------------------------------------------------
-// Module-level state
+// Plugin runtime and isolated session state
 // ---------------------------------------------------------------------------
 
 let client: CyclesClient;
 let config: BudgetGuardConfig;
 let logger: OpenClawLogger;
 
-/** In-flight reservations keyed by callId (tools) or model:<uuid> (models). */
-const activeReservations = new Map<string, ActiveReservation>();
+interface SessionState {
+  /** In-flight tool reservations keyed by the host's toolCallId. */
+  activeReservations: Map<string, ActiveReservation>;
+  cachedSnapshot?: BudgetSnapshot;
+  cachedSnapshotAt: number;
+  totalReservationsMade: number;
+  lastKnownLevel?: BudgetLevel;
+  costBreakdown: Map<string, { count: number; totalCost: number }>;
+  totalToolCost: number;
+  totalToolCalls: number;
+  totalModelCost: number;
+  totalModelCalls: number;
+  remainingCallsAllowed: number;
+  toolCallCounts: Map<string, number>;
+  warnedUnconfiguredTools: Set<string>;
+  sessionStartedAt: number;
+  resolvedUserId?: string;
+  resolvedSessionId?: string;
+  /** One pending model hold per isolated session/run. */
+  pendingModelReservation?: ActiveReservation;
+  pendingModelName?: string;
+  turnIndex: number;
+  heartbeatTimers: Map<string, ReturnType<typeof setInterval>>;
+  eventLog: ReservationLogEntry[];
+  windowCostAtStart: number;
+  windowStartedAt: number;
+  lastBurnRate: number;
+  exhaustionWarningFired: boolean;
+  eventLogCapWarned: boolean;
+}
 
-/** Cached budget snapshot with configurable time-based freshness. */
-let cachedSnapshot: BudgetSnapshot | undefined;
-let cachedSnapshotAt = 0;
-
-/** Session-level counters for the final summary. */
-let totalReservationsMade = 0;
-
-/** Gap 5: Last known budget level for transition detection. */
-let lastKnownLevel: BudgetLevel | undefined;
-
-/** Gap 6: Per-component cost breakdown. */
-const costBreakdown = new Map<string, { count: number; totalCost: number }>();
-
-/** Gap 9: Running totals for forecast. */
-let totalToolCost = 0;
-let totalToolCalls = 0;
-let totalModelCost = 0;
-let totalModelCalls = 0;
-
-/** Gap 13: Remaining calls counter for limit_remaining_calls strategy. */
-let remainingCallsAllowed = 0;
-
-/** Per-tool invocation counters for toolCallLimits enforcement. */
-const toolCallCounts = new Map<string, number>();
-
-/** Tools already warned about missing toolBaseCosts entry. */
-const warnedUnconfiguredTools = new Set<string>();
-
-/** Gap 15: Session start time. */
-let sessionStartedAt = 0;
-
-/** Resolved userId/sessionId (from config + ctx overrides). */
-let resolvedUserId: string | undefined;
-let resolvedSessionId: string | undefined;
-
-/** v0.5.0: Pending model reservation for reserve-then-commit pattern. */
-let pendingModelReservation: ActiveReservation | undefined;
-let pendingModelName: string | undefined;
-
-/** v0.5.0: Turn counter for model cost estimator context. */
-let turnIndex = 0;
+/** All mutable hook lifecycle state, keyed by a stable OpenClaw scope. */
+const sessionStates = new Map<string, SessionState>();
 
 /** v0.5.0: Metrics emitter reference (from config or OTLP auto-creation). */
 let metricsEmitter: MetricsEmitter | undefined;
 
 /** v0.5.0: Base tags for all metrics. */
 let baseTags: Record<string, string> = {};
-
-/** v0.6.0: Heartbeat timers for long-running tool reservations. */
-const heartbeatTimers = new Map<string, ReturnType<typeof setInterval>>();
-
-/** v0.6.0: Session event log. */
-const eventLog: ReservationLogEntry[] = [];
-
-/** v0.6.0: Burn rate tracking — cost snapshots per window. */
-let windowCostAtStart = 0;
-let windowStartedAt = 0;
-let lastBurnRate = 0;
-let exhaustionWarningFired = false;
-let eventLogCapWarned = false;
-
 
 // ---------------------------------------------------------------------------
 // Initialization
@@ -154,66 +131,133 @@ export function initHooks(
   }
 
   // OpenClaw calls the plugin entrypoint (and thus initHooks) multiple times —
-  // once per channel/worker. Only reset session state on the first init.
-  // Subsequent inits update config/client/logger but preserve accumulated
-  // counters (toolCallCounts, costBreakdown, etc.) so toolCallLimits and
-  // session tracking work correctly across the session.
+  // once per channel/worker. Only reset isolated states on the first init.
+  // Subsequent inits update config/client/logger while preserving each
+  // session's own counters and reservations.
   if (initialized) {
     return;
   }
   initialized = true;
 
-  cachedSnapshot = undefined;
-  cachedSnapshotAt = 0;
-  totalReservationsMade = 0;
-  lastKnownLevel = undefined;
-  activeReservations.clear();
-  costBreakdown.clear();
-  toolCallCounts.clear();
-  warnedUnconfiguredTools.clear();
-  totalToolCost = 0;
-  totalToolCalls = 0;
-  totalModelCost = 0;
-  totalModelCalls = 0;
-  remainingCallsAllowed = config.maxRemainingCallsWhenLow;
-  sessionStartedAt = Date.now();
-  resolvedUserId = config.userId;
-  resolvedSessionId = config.sessionId;
-
-  // v0.5.0: Reset model reservation tracking
-  pendingModelReservation = undefined;
-  pendingModelName = undefined;
-  turnIndex = 0;
-
-  // v0.6.0: Reset new state
-  for (const timer of heartbeatTimers.values()) clearInterval(timer);
-  heartbeatTimers.clear();
-  eventLog.length = 0;
-  windowCostAtStart = 0;
-  windowStartedAt = Date.now();
-  lastBurnRate = 0;
-  exhaustionWarningFired = false;
-  eventLogCapWarned = false;
+  for (const state of sessionStates.values()) stopAllHeartbeats(state);
+  sessionStates.clear();
 }
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-async function getSnapshot(ctx?: HookContext): Promise<BudgetSnapshot> {
-  const now = Date.now();
-  if (cachedSnapshot && now - cachedSnapshotAt < config.snapshotCacheTtlMs) {
-    return cachedSnapshot;
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function resolveScope(
+  event: Record<string, unknown>,
+  ctx: HookContext,
+): { key: string; userId?: string; sessionId?: string } {
+  const metadata = ctx.metadata ?? {};
+  const scopeKey = (kind: string, id: string) => JSON.stringify([config.tenant, kind, id]);
+  const userId = asNonEmptyString(metadata.userId) ?? config.userId;
+  const hostSessionId = asNonEmptyString(ctx.sessionId)
+    ?? asNonEmptyString(metadata.sessionId)
+    ?? asNonEmptyString(event.sessionId);
+  if (hostSessionId) {
+    return { key: scopeKey("session", hostSessionId), userId, sessionId: hostSessionId };
   }
-  const userId = (ctx?.metadata?.userId as string | undefined) ?? resolvedUserId;
-  const sessionId = (ctx?.metadata?.sessionId as string | undefined) ?? resolvedSessionId;
+
+  const sessionKey = asNonEmptyString(ctx.sessionKey)
+    ?? asNonEmptyString(metadata.sessionKey)
+    ?? asNonEmptyString(ctx.conversationId)
+    ?? asNonEmptyString(metadata.conversationId)
+    ?? asNonEmptyString(event.sessionKey)
+    ?? asNonEmptyString(event.conversationId);
+  if (sessionKey) {
+    return { key: scopeKey("session-key", sessionKey), userId, sessionId: config.sessionId };
+  }
+
+  const runId = asNonEmptyString(ctx.runId)
+    ?? asNonEmptyString(metadata.runId)
+    ?? asNonEmptyString(event.runId);
+  if (runId) return { key: scopeKey("run", runId), userId, sessionId: config.sessionId };
+
+  if (config.sessionId) {
+    return {
+      key: scopeKey("configured-session", config.sessionId),
+      userId,
+      sessionId: config.sessionId,
+    };
+  }
+
+  const agentId = asNonEmptyString(ctx.agentId)
+    ?? asNonEmptyString(metadata.agentId)
+    ?? asNonEmptyString(event.agentId);
+  if (agentId) {
+    return { key: scopeKey("agent", agentId), userId, sessionId: config.sessionId };
+  }
+  if (userId) return { key: scopeKey("user", userId), userId, sessionId: config.sessionId };
+
+  return { key: scopeKey("unscoped", "default"), sessionId: config.sessionId };
+}
+
+function createSessionState(identity: { userId?: string; sessionId?: string }): SessionState {
+  const now = Date.now();
+  return {
+    activeReservations: new Map(),
+    cachedSnapshotAt: 0,
+    totalReservationsMade: 0,
+    costBreakdown: new Map(),
+    totalToolCost: 0,
+    totalToolCalls: 0,
+    totalModelCost: 0,
+    totalModelCalls: 0,
+    remainingCallsAllowed: config.maxRemainingCallsWhenLow,
+    toolCallCounts: new Map(),
+    warnedUnconfiguredTools: new Set(),
+    sessionStartedAt: now,
+    resolvedUserId: identity.userId,
+    resolvedSessionId: identity.sessionId,
+    turnIndex: 0,
+    heartbeatTimers: new Map(),
+    eventLog: [],
+    windowCostAtStart: 0,
+    windowStartedAt: now,
+    lastBurnRate: 0,
+    exhaustionWarningFired: false,
+    eventLogCapWarned: false,
+  };
+}
+
+function getSessionState(
+  event: Record<string, unknown>,
+  ctx: HookContext,
+): { key: string; state: SessionState } {
+  const identity = resolveScope(event, ctx);
+  let state = sessionStates.get(identity.key);
+  if (!state) {
+    state = createSessionState(identity);
+    sessionStates.set(identity.key, state);
+  } else {
+    state.resolvedUserId = identity.userId ?? state.resolvedUserId;
+    state.resolvedSessionId = identity.sessionId ?? state.resolvedSessionId;
+  }
+  return { key: identity.key, state };
+}
+
+async function getSnapshot(state: SessionState): Promise<BudgetSnapshot> {
+  const now = Date.now();
+  if (state.cachedSnapshot && now - state.cachedSnapshotAt < config.snapshotCacheTtlMs) {
+    return state.cachedSnapshot;
+  }
 
   // Timeout guard: don't let a hung Cycles server block hook execution
   const SNAPSHOT_TIMEOUT_MS = 10_000;
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
-    cachedSnapshot = await Promise.race([
-      fetchBudgetState(client, config, logger, { userId, sessionId }),
+    state.cachedSnapshot = await Promise.race([
+      fetchBudgetState(client, config, logger, {
+        userId: state.resolvedUserId,
+        sessionId: state.resolvedSessionId,
+      }),
       new Promise<never>((_, reject) => {
         timeoutHandle = setTimeout(() => reject(new Error("fetchBudgetState timed out")), SNAPSHOT_TIMEOUT_MS);
       }),
@@ -221,23 +265,23 @@ async function getSnapshot(ctx?: HookContext): Promise<BudgetSnapshot> {
   } catch (err) {
     if (config.failClosedOnSnapshotError) {
       logger.warn(`Budget snapshot fetch failed (${err}), failing closed (exhausted)`);
-      cachedSnapshot = { remaining: 0, reserved: 0, spent: 0, level: "exhausted" };
+      state.cachedSnapshot = { remaining: 0, reserved: 0, spent: 0, level: "exhausted" };
     } else {
       logger.warn(`Budget snapshot fetch failed (${err}), assuming healthy`);
-      cachedSnapshot = { remaining: Infinity, reserved: 0, spent: 0, level: "healthy" };
+      state.cachedSnapshot = { remaining: Infinity, reserved: 0, spent: 0, level: "healthy" };
     }
   } finally {
     clearTimeout(timeoutHandle);
   }
-  cachedSnapshotAt = now;
+  state.cachedSnapshotAt = now;
 
   // Gap 5: Detect budget level transitions
-  if (lastKnownLevel !== undefined && cachedSnapshot.level !== lastKnownLevel) {
-    logger.warn(`Budget level changed: ${lastKnownLevel} → ${cachedSnapshot.level} (remaining=${cachedSnapshot.remaining})`);
+  if (state.lastKnownLevel !== undefined && state.cachedSnapshot.level !== state.lastKnownLevel) {
+    logger.warn(`Budget level changed: ${state.lastKnownLevel} → ${state.cachedSnapshot.level} (remaining=${state.cachedSnapshot.remaining})`);
     const event = {
-      previousLevel: lastKnownLevel,
-      currentLevel: cachedSnapshot.level,
-      remaining: cachedSnapshot.remaining,
+      previousLevel: state.lastKnownLevel,
+      currentLevel: state.cachedSnapshot.level,
+      remaining: state.cachedSnapshot.remaining,
       timestamp: now,
     };
     try {
@@ -249,21 +293,21 @@ async function getSnapshot(ctx?: HookContext): Promise<BudgetSnapshot> {
       fireWebhook(config.budgetTransitionWebhookUrl, event);
     }
   }
-  lastKnownLevel = cachedSnapshot.level;
+  state.lastKnownLevel = state.cachedSnapshot.level;
 
   // v0.5.0: Emit budget gauge metrics
-  emitGauge("cycles.budget.remaining", cachedSnapshot.remaining, { currency: config.currency });
-  emitGauge("cycles.budget.reserved", cachedSnapshot.reserved);
-  emitGauge("cycles.budget.spent", cachedSnapshot.spent);
-  const levelValue = cachedSnapshot.level === "healthy" ? 0 : cachedSnapshot.level === "low" ? 1 : 2;
-  emitGauge("cycles.budget.level", levelValue, { level: cachedSnapshot.level });
+  emitGauge("cycles.budget.remaining", state.cachedSnapshot.remaining, { currency: config.currency });
+  emitGauge("cycles.budget.reserved", state.cachedSnapshot.reserved);
+  emitGauge("cycles.budget.spent", state.cachedSnapshot.spent);
+  const levelValue = state.cachedSnapshot.level === "healthy" ? 0 : state.cachedSnapshot.level === "low" ? 1 : 2;
+  emitGauge("cycles.budget.level", levelValue, { level: state.cachedSnapshot.level });
 
-  return cachedSnapshot;
+  return state.cachedSnapshot;
 }
 
-function invalidateSnapshotCache(): void {
-  cachedSnapshot = undefined;
-  cachedSnapshotAt = 0;
+function invalidateSnapshotCache(state: SessionState): void {
+  state.cachedSnapshot = undefined;
+  state.cachedSnapshotAt = 0;
 }
 
 /** Gap 12: Attach budget status to ctx.metadata for end-user visibility. */
@@ -282,23 +326,23 @@ function attachBudgetStatus(ctx: HookContext, snapshot: BudgetSnapshot): void {
 }
 
 /** Gap 6: Update cost breakdown tracking. */
-function trackCost(key: string, cost: number): void {
-  const entry = costBreakdown.get(key);
+function trackCost(state: SessionState, key: string, cost: number): void {
+  const entry = state.costBreakdown.get(key);
   if (entry) {
     entry.count++;
     entry.totalCost += cost;
   } else {
-    costBreakdown.set(key, { count: 1, totalCost: cost });
+    state.costBreakdown.set(key, { count: 1, totalCost: cost });
   }
 }
 
 /** Gap 9: Build forecast data from running totals. */
-function buildForecast(): ForecastData {
+function buildForecast(state: SessionState): ForecastData {
   return {
-    avgToolCost: totalToolCalls > 0 ? totalToolCost / totalToolCalls : 0,
-    avgModelCost: totalModelCalls > 0 ? totalModelCost / totalModelCalls : 0,
-    totalToolCalls,
-    totalModelCalls,
+    avgToolCost: state.totalToolCalls > 0 ? state.totalToolCost / state.totalToolCalls : 0,
+    avgModelCost: state.totalModelCalls > 0 ? state.totalModelCost / state.totalModelCalls : 0,
+    totalToolCalls: state.totalToolCalls,
+    totalModelCalls: state.totalModelCalls,
   };
 }
 
@@ -336,37 +380,37 @@ function emitHistogram(name: string, value: number, tags?: Record<string, string
 const MAX_EVENT_LOG_ENTRIES = 10_000;
 
 /** v0.6.0: Append to event log if enabled. Capped to prevent unbounded growth. */
-function logEvent(entry: ReservationLogEntry): void {
+function logEvent(state: SessionState, entry: ReservationLogEntry): void {
   if (!config.enableEventLog) return;
-  if (eventLog.length >= MAX_EVENT_LOG_ENTRIES) {
-    if (!eventLogCapWarned) {
-      eventLogCapWarned = true;
+  if (state.eventLog.length >= MAX_EVENT_LOG_ENTRIES) {
+    if (!state.eventLogCapWarned) {
+      state.eventLogCapWarned = true;
       logger.warn(`Event log capacity (${MAX_EVENT_LOG_ENTRIES} entries) reached — further events will be dropped`);
     }
     return;
   }
-  eventLog.push(entry);
+  state.eventLog.push(entry);
 }
 
 /** v0.6.0: Get current session cost total. */
-function sessionCostTotal(): number {
+function sessionCostTotal(state: SessionState): number {
   let total = 0;
-  for (const e of costBreakdown.values()) total += e.totalCost;
+  for (const e of state.costBreakdown.values()) total += e.totalCost;
   return total;
 }
 
 /** v0.6.0: Check burn rate and fire anomaly if needed. */
-function checkBurnRate(remaining: number): void {
+function checkBurnRate(state: SessionState, remaining: number): void {
   const now = Date.now();
-  const elapsed = now - windowStartedAt;
+  const elapsed = now - state.windowStartedAt;
   if (elapsed < config.burnRateWindowMs || elapsed <= 0) return;
 
-  const currentTotal = sessionCostTotal();
-  const windowCost = currentTotal - windowCostAtStart;
+  const currentTotal = sessionCostTotal(state);
+  const windowCost = currentTotal - state.windowCostAtStart;
   const currentRate = windowCost / elapsed; // cost per ms
 
-  if (lastBurnRate > 0 && currentRate > 0) {
-    const ratio = currentRate / lastBurnRate;
+  if (state.lastBurnRate > 0 && currentRate > 0) {
+    const ratio = currentRate / state.lastBurnRate;
     if (ratio >= config.burnRateAlertThreshold) {
       logger.warn(
         `Burn rate anomaly: ${ratio.toFixed(1)}x above average (threshold: ${config.burnRateAlertThreshold}x)`,
@@ -374,7 +418,7 @@ function checkBurnRate(remaining: number): void {
       emitCounter("cycles.budget.burn_rate_anomaly", 1, { ratio: ratio.toFixed(1) });
       const event = {
         currentBurnRate: currentRate,
-        averageBurnRate: lastBurnRate,
+        averageBurnRate: state.lastBurnRate,
         ratio,
         threshold: config.burnRateAlertThreshold,
         windowMs: config.burnRateWindowMs,
@@ -385,18 +429,18 @@ function checkBurnRate(remaining: number): void {
     }
   }
 
-  lastBurnRate = currentRate > 0 ? currentRate : lastBurnRate;
-  windowCostAtStart = currentTotal;
-  windowStartedAt = now;
+  state.lastBurnRate = currentRate > 0 ? currentRate : state.lastBurnRate;
+  state.windowCostAtStart = currentTotal;
+  state.windowStartedAt = now;
 }
 
 /** v0.6.0: Check if budget will exhaust soon and warn. */
-function checkExhaustionForecast(remaining: number): void {
-  if (exhaustionWarningFired || remaining === Infinity) return;
-  const elapsed = Date.now() - sessionStartedAt;
+function checkExhaustionForecast(state: SessionState, remaining: number): void {
+  if (state.exhaustionWarningFired || remaining === Infinity) return;
+  const elapsed = Date.now() - state.sessionStartedAt;
   if (elapsed < 1000) return; // need at least 1s of data
 
-  const totalCost = sessionCostTotal();
+  const totalCost = sessionCostTotal(state);
   if (totalCost <= 0) return;
 
   const burnRatePerMs = totalCost / elapsed;
@@ -404,7 +448,7 @@ function checkExhaustionForecast(remaining: number): void {
   const msRemaining = remaining / burnRatePerMs;
 
   if (msRemaining < config.exhaustionWarningThresholdMs) {
-    exhaustionWarningFired = true;
+    state.exhaustionWarningFired = true;
     logger.warn(
       `Budget exhaustion forecast: ~${Math.round(msRemaining / 1000)}s remaining at current burn rate`,
     );
@@ -420,45 +464,53 @@ function checkExhaustionForecast(remaining: number): void {
 }
 
 /** v0.6.0: Start heartbeat timer for a tool reservation. */
-function startHeartbeat(toolCallId: string, reservationId: string): void {
+function startHeartbeat(state: SessionState, toolCallId: string, reservationId: string): void {
   if (config.heartbeatIntervalMs <= 0) return;
+  const heartbeatClient = client;
+  const heartbeatIntervalMs = config.heartbeatIntervalMs;
+  const heartbeatLogger = logger;
   const timer = setInterval(async () => {
     try {
       const body: Record<string, unknown> = {
         idempotency_key: `extend-${reservationId}-${Date.now()}`,
-        extend_by_ms: config.heartbeatIntervalMs,
+        extend_by_ms: heartbeatIntervalMs,
       };
       // Use client.extendReservation if available, otherwise skip
-      if ("extendReservation" in client && typeof (client as unknown as Record<string, unknown>).extendReservation === "function") {
-        await (client as unknown as { extendReservation(id: string, body: Record<string, unknown>): Promise<unknown> })
+      if ("extendReservation" in heartbeatClient && typeof (heartbeatClient as unknown as Record<string, unknown>).extendReservation === "function") {
+        await (heartbeatClient as unknown as { extendReservation(id: string, body: Record<string, unknown>): Promise<unknown> })
           .extendReservation(reservationId, body);
-        logger.debug(`Heartbeat: extended reservation ${reservationId} for tool callId=${toolCallId}`);
+        heartbeatLogger.debug(`Heartbeat: extended reservation ${reservationId} for tool callId=${toolCallId}`);
       }
     } catch {
-      logger.debug(`Heartbeat: failed to extend reservation ${reservationId}`);
+      heartbeatLogger.debug(`Heartbeat: failed to extend reservation ${reservationId}`);
     }
-  }, config.heartbeatIntervalMs);
+  }, heartbeatIntervalMs);
   if (typeof timer === "object" && "unref" in timer) timer.unref();
-  heartbeatTimers.set(toolCallId, timer);
+  state.heartbeatTimers.set(toolCallId, timer);
 }
 
 /** v0.6.0: Stop heartbeat timer for a tool call. */
-function stopHeartbeat(toolCallId: string): void {
-  const timer = heartbeatTimers.get(toolCallId);
+function stopHeartbeat(state: SessionState, toolCallId: string): void {
+  const timer = state.heartbeatTimers.get(toolCallId);
   if (timer) {
     clearInterval(timer);
-    heartbeatTimers.delete(toolCallId);
+    state.heartbeatTimers.delete(toolCallId);
   }
 }
 
-/** v0.5.0: Commit pending model reservation from previous turn. */
-async function commitPendingModelReservation(): Promise<void> {
-  if (!pendingModelReservation) return;
+function stopAllHeartbeats(state: SessionState): void {
+  for (const timer of state.heartbeatTimers.values()) clearInterval(timer);
+  state.heartbeatTimers.clear();
+}
 
-  const reservation = pendingModelReservation;
-  const modelName = pendingModelName ?? "unknown";
-  pendingModelReservation = undefined;
-  pendingModelName = undefined;
+/** v0.5.0: Commit pending model reservation from previous turn. */
+async function commitPendingModelReservation(state: SessionState): Promise<void> {
+  if (!state.pendingModelReservation) return;
+
+  const reservation = state.pendingModelReservation;
+  const modelName = state.pendingModelName ?? "unknown";
+  state.pendingModelReservation = undefined;
+  state.pendingModelName = undefined;
 
   let actual = reservation.estimate;
   if (config.modelCostEstimator) {
@@ -466,7 +518,7 @@ async function commitPendingModelReservation(): Promise<void> {
       const computed = config.modelCostEstimator({
         model: modelName,
         estimatedCost: reservation.estimate,
-        turnIndex: turnIndex - 1,
+        turnIndex: state.turnIndex - 1,
       });
       if (computed != null) actual = computed;
     } catch (err) {
@@ -479,17 +531,17 @@ async function commitPendingModelReservation(): Promise<void> {
   await commitUsage(client, reservation.reservationId, actual, unit, logger, metrics);
   logger.info(`Model committed: ${modelName} (cost=${actual} ${unit})`);
 
-  trackCost(`model:${modelName}`, actual);
-  totalModelCost += actual;
-  totalModelCalls++;
+  trackCost(state, `model:${modelName}`, actual);
+  state.totalModelCost += actual;
+  state.totalModelCalls++;
 
   emitCounter("cycles.reservation.committed", 1, { kind: "model", name: modelName });
   emitHistogram("cycles.reservation.cost", actual, { kind: "model", name: modelName });
-  logEvent({ timestamp: Date.now(), hook: "commit_model", action: "commit", kind: "model", name: modelName, amount: actual, budgetLevel: cachedSnapshot?.level ?? "healthy", remaining: cachedSnapshot?.remaining ?? 0 });
+  logEvent(state, { timestamp: Date.now(), hook: "commit_model", action: "commit", kind: "model", name: modelName, amount: actual, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
 
-  invalidateSnapshotCache();
+  invalidateSnapshotCache(state);
   if (config.aggressiveCacheInvalidation) {
-    await getSnapshot();
+    await getSnapshot(state);
   }
 }
 
@@ -504,17 +556,15 @@ export async function beforeModelResolve(
   event: ModelResolveEvent,
   ctx: HookContext,
 ): Promise<ModelResolveResult | undefined> {
-  // Gap 3: Resolve user/session from ctx if available
-  if (ctx.metadata?.userId) resolvedUserId = ctx.metadata.userId as string;
-  if (ctx.metadata?.sessionId) resolvedSessionId = ctx.metadata.sessionId as string;
-
-  const snapshot = await getSnapshot(ctx);
+  const { state } = getSessionState(event, ctx);
+  const snapshot = await getSnapshot(state);
 
   // Resolve model name — check event fields, ctx.metadata, and config fallback.
   // OpenClaw may pass the model in different places depending on version.
   const eventRecord = event as Record<string, unknown>;
   const ctxMeta = (ctx.metadata ?? {}) as Record<string, unknown>;
   const eventModel = event.model
+    ?? ctx.modelId
     ?? eventRecord.modelId as string | undefined
     ?? eventRecord.modelName as string | undefined
     ?? eventRecord.model_id as string | undefined
@@ -564,8 +614,8 @@ export async function beforeModelResolve(
     }
 
     // Gap 13: Apply low-budget strategies
-    if (config.lowBudgetStrategies.includes("limit_remaining_calls") && remainingCallsAllowed <= 0) {
-      logEvent({ timestamp: Date.now(), hook: "before_model_resolve", action: "deny", kind: "model", name: eventModel, reason: "remaining_calls", budgetLevel: snapshot.level, remaining: snapshot.remaining });
+    if (config.lowBudgetStrategies.includes("limit_remaining_calls") && state.remainingCallsAllowed <= 0) {
+      logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "deny", kind: "model", name: eventModel, reason: "remaining_calls", budgetLevel: snapshot.level, remaining: snapshot.remaining });
       if (config.failClosed) {
         logger.warn(`Call limit reached for model ${eventModel} — budget is low, blocking model call`);
         return { modelOverride: "__cycles_budget_exhausted__" };
@@ -579,7 +629,7 @@ export async function beforeModelResolve(
       logger.warn(
         `Budget exhausted (${snapshot.remaining} remaining) — blocking model call for ${eventModel}`,
       );
-      logEvent({ timestamp: Date.now(), hook: "before_model_resolve", action: "deny", kind: "model", name: eventModel, reason: "budget_exhausted", budgetLevel: snapshot.level, remaining: snapshot.remaining });
+      logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "deny", kind: "model", name: eventModel, reason: "budget_exhausted", budgetLevel: snapshot.level, remaining: snapshot.remaining });
       return { modelOverride: "__cycles_budget_exhausted__" };
     }
     logger.warn(
@@ -597,12 +647,14 @@ export async function beforeModelResolve(
     actionName: resolvedModel,
     estimate: modelCost,
     unit: modelCurrency,
+    userId: state.resolvedUserId,
+    sessionId: state.resolvedSessionId,
   });
 
   if (!isAllowed(result.decision)) {
     const reason = result.reasonCode ?? "denied";
     emitCounter("cycles.reservation.denied", 1, { kind: "model", name: resolvedModel, reason });
-    logEvent({ timestamp: Date.now(), hook: "before_model_resolve", action: "deny", kind: "model", name: resolvedModel, decision: result.decision, reason, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+    logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "deny", kind: "model", name: resolvedModel, decision: result.decision, reason, budgetLevel: snapshot.level, remaining: snapshot.remaining });
 
     if (config.failClosed) {
       logger.warn(`Model reservation denied for ${resolvedModel} (reason: ${reason}, budget: ${snapshot.level}) — blocking model call (failClosed=true)`);
@@ -613,31 +665,31 @@ export async function beforeModelResolve(
     // Track cost locally even though no server-side reservation was created.
     // The model call will proceed, so the session summary and forecasting
     // should reflect the estimated cost.
-    trackCost(`model:${resolvedModel}`, modelCost);
-    totalModelCost += modelCost;
-    totalModelCalls++;
-    turnIndex++;
+    trackCost(state, `model:${resolvedModel}`, modelCost);
+    state.totalModelCost += modelCost;
+    state.totalModelCalls++;
+    state.turnIndex++;
     if (snapshot.level === "low" && config.lowBudgetStrategies.includes("limit_remaining_calls")) {
-      remainingCallsAllowed--;
+      state.remainingCallsAllowed--;
     }
-    invalidateSnapshotCache();
+    invalidateSnapshotCache(state);
 
-    logEvent({ timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: result.decision, reason: `${reason}:allowed_without_reservation`, budgetLevel: snapshot.level, remaining: snapshot.remaining });
-    checkBurnRate(snapshot.remaining);
-    checkExhaustionForecast(snapshot.remaining);
+    logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: result.decision, reason: `${reason}:allowed_without_reservation`, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+    checkBurnRate(state, snapshot.remaining);
+    checkExhaustionForecast(state, snapshot.remaining);
   } else {
-    totalReservationsMade++;
+    state.totalReservationsMade++;
     emitCounter("cycles.reservation.created", 1, { kind: "model", name: resolvedModel });
     logger.info(`Model reserved: ${resolvedModel} (estimate=${modelCost}, remaining=${snapshot.remaining})`);
 
     // v0.5.0: Commit any pending model reservation from previous turn first
-    await commitPendingModelReservation();
+    await commitPendingModelReservation(state);
 
     if (result.reservationId) {
       // v0.5.0: Reserve-then-commit pattern — hold the reservation open.
       // It will be committed in the next beforePromptBuild or at agentEnd,
       // allowing modelCostEstimator to reconcile the cost.
-      pendingModelReservation = {
+      state.pendingModelReservation = {
         reservationId: result.reservationId,
         estimate: modelCost,
         toolName: resolvedModel,
@@ -645,23 +697,23 @@ export async function beforeModelResolve(
         kind: "model",
         currency: modelCurrency,
       };
-      pendingModelName = resolvedModel;
+      state.pendingModelName = resolvedModel;
     } else {
       // No reservation ID (e.g. dry-run with DENY) — track immediately
-      trackCost(`model:${resolvedModel}`, modelCost);
-      totalModelCost += modelCost;
-      totalModelCalls++;
+      trackCost(state, `model:${resolvedModel}`, modelCost);
+      state.totalModelCost += modelCost;
+      state.totalModelCalls++;
     }
 
-    turnIndex++;
+    state.turnIndex++;
     if (snapshot.level === "low" && config.lowBudgetStrategies.includes("limit_remaining_calls")) {
-      remainingCallsAllowed--;
+      state.remainingCallsAllowed--;
     }
-    invalidateSnapshotCache();
+    invalidateSnapshotCache(state);
 
-    logEvent({ timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: result.decision, budgetLevel: snapshot.level, remaining: snapshot.remaining });
-    checkBurnRate(snapshot.remaining);
-    checkExhaustionForecast(snapshot.remaining);
+    logEvent(state, { timestamp: Date.now(), hook: "before_model_resolve", action: "reserve", kind: "model", name: resolvedModel, amount: modelCost, decision: result.decision, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+    checkBurnRate(state, snapshot.remaining);
+    checkExhaustionForecast(state, snapshot.remaining);
   }
 
   if (resolvedModel !== eventModel) {
@@ -681,21 +733,22 @@ export async function beforeModelResolve(
 // ---------------------------------------------------------------------------
 
 export async function beforePromptBuild(
-  _event: PromptBuildEvent,
+  event: PromptBuildEvent,
   ctx: HookContext,
 ): Promise<PromptBuildResult | undefined> {
+  const { state } = getSessionState(event, ctx);
   // v0.5.0: Commit pending model reservation from previous turn
-  await commitPendingModelReservation();
+  await commitPendingModelReservation(state);
 
   if (!config.injectPromptBudgetHint) return undefined;
 
-  const snapshot = await getSnapshot(ctx);
+  const snapshot = await getSnapshot(state);
 
   // Gap 12: Attach status
   attachBudgetStatus(ctx, snapshot);
 
   // Gap 9: Include forecast data in hint
-  const forecast = buildForecast();
+  const forecast = buildForecast(state);
   const hint = formatBudgetHint(snapshot, config, forecast);
   logger.debug(`before_prompt_build: injecting hint (${hint.length} chars)`);
 
@@ -734,16 +787,14 @@ export async function beforeToolCall(
     return { block: true, blockReason: "Missing tool call ID in event" };
   }
 
-  // Resolve user/session from ctx if available (consistent with beforeModelResolve)
-  if (ctx.metadata?.userId) resolvedUserId = ctx.metadata.userId as string;
-  if (ctx.metadata?.sessionId) resolvedSessionId = ctx.metadata.sessionId as string;
+  const { state } = getSessionState(event, ctx);
 
   // Gap 7: Check tool allowlist/blocklist
   const permission = isToolPermitted(toolName, config.toolAllowlist, config.toolBlocklist);
   if (!permission.permitted) {
     logger.warn(`Tool "${toolName}" blocked by access list: ${permission.reason}`);
     emitCounter("cycles.tool.blocked", 1, { tool: toolName, reason: "access_list" });
-    logEvent({ timestamp: Date.now(), hook: "before_tool_call", action: "block", kind: "tool", name: toolName, reason: permission.reason, budgetLevel: cachedSnapshot?.level ?? "healthy", remaining: cachedSnapshot?.remaining ?? 0 });
+    logEvent(state, { timestamp: Date.now(), hook: "before_tool_call", action: "block", kind: "tool", name: toolName, reason: permission.reason, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
     return { block: true, blockReason: permission.reason };
   }
 
@@ -751,11 +802,11 @@ export async function beforeToolCall(
   if (config.toolCallLimits) {
     const limit = config.toolCallLimits[toolName];
     if (limit !== undefined) {
-      const count = toolCallCounts.get(toolName) ?? 0;
+      const count = state.toolCallCounts.get(toolName) ?? 0;
       if (count >= limit) {
         logger.warn(`Tool "${toolName}" blocked: call limit ${limit} reached (${count} calls)`);
         emitCounter("cycles.tool.blocked", 1, { tool: toolName, reason: "call_limit" });
-        logEvent({ timestamp: Date.now(), hook: "before_tool_call", action: "block", kind: "tool", name: toolName, reason: `call_limit:${limit}`, budgetLevel: cachedSnapshot?.level ?? "healthy", remaining: cachedSnapshot?.remaining ?? 0 });
+        logEvent(state, { timestamp: Date.now(), hook: "before_tool_call", action: "block", kind: "tool", name: toolName, reason: `call_limit:${limit}`, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
         return {
           block: true,
           blockReason: `Tool "${toolName}" exceeded session call limit (${limit})`,
@@ -765,13 +816,13 @@ export async function beforeToolCall(
   }
 
   // Gap 12: Attach budget status
-  const snapshot = await getSnapshot(ctx);
+  const snapshot = await getSnapshot(state);
   attachBudgetStatus(ctx, snapshot);
 
   // Log once per tool when using default cost estimate
   const estimate = config.toolBaseCosts[toolName] ?? DEFAULT_TOOL_COST;
-  if (!(toolName in config.toolBaseCosts) && !warnedUnconfiguredTools.has(toolName)) {
-    warnedUnconfiguredTools.add(toolName);
+  if (!(toolName in config.toolBaseCosts) && !state.warnedUnconfiguredTools.has(toolName)) {
+    state.warnedUnconfiguredTools.add(toolName);
     logger.warn(
       `Tool "${toolName}" has no entry in toolBaseCosts — using default estimate (${DEFAULT_TOOL_COST} ${config.currency}). Add it to toolBaseCosts for accurate budgeting.`,
     );
@@ -788,7 +839,7 @@ export async function beforeToolCall(
         `Tool "${toolName}" blocked: cost ${estimate} exceeds expensive threshold ${threshold}`,
       );
       emitCounter("cycles.tool.blocked", 1, { tool: toolName, reason: "expensive" });
-      logEvent({ timestamp: Date.now(), hook: "before_tool_call", action: "block", kind: "tool", name: toolName, reason: "expensive", budgetLevel: snapshot.level, remaining: snapshot.remaining });
+      logEvent(state, { timestamp: Date.now(), hook: "before_tool_call", action: "block", kind: "tool", name: toolName, reason: "expensive", budgetLevel: snapshot.level, remaining: snapshot.remaining });
       return {
         block: true,
         blockReason: `Tool "${toolName}" disabled during low budget (cost ${estimate} exceeds threshold ${threshold})`,
@@ -800,11 +851,11 @@ export async function beforeToolCall(
   if (
     snapshot.level === "low" &&
     config.lowBudgetStrategies.includes("limit_remaining_calls") &&
-    remainingCallsAllowed <= 0
+    state.remainingCallsAllowed <= 0
   ) {
     logger.warn(`Tool "${toolName}" blocked: remaining call limit reached`);
     emitCounter("cycles.tool.blocked", 1, { tool: toolName, reason: "remaining_calls" });
-    logEvent({ timestamp: Date.now(), hook: "before_tool_call", action: "block", kind: "tool", name: toolName, reason: "remaining_calls", budgetLevel: snapshot.level, remaining: snapshot.remaining });
+    logEvent(state, { timestamp: Date.now(), hook: "before_tool_call", action: "block", kind: "tool", name: toolName, reason: "remaining_calls", budgetLevel: snapshot.level, remaining: snapshot.remaining });
     return {
       block: true,
       blockReason: `Tool call limit reached during low budget (max ${config.maxRemainingCallsWhenLow} calls)`,
@@ -827,6 +878,8 @@ export async function beforeToolCall(
     ttlMs,
     overagePolicy,
     unit,
+    userId: state.resolvedUserId,
+    sessionId: state.resolvedSessionId,
   });
 
   if (!isAllowed(result.decision)) {
@@ -837,7 +890,7 @@ export async function beforeToolCall(
           `Tool "${toolName}" denied, retry ${attempt + 1}/${config.maxRetries} after ${config.retryDelayMs}ms`,
         );
         await sleep(config.retryDelayMs);
-        invalidateSnapshotCache();
+        invalidateSnapshotCache(state);
         const retry = await reserveBudget(client, config, {
           actionKind,
           actionName: toolName,
@@ -845,11 +898,13 @@ export async function beforeToolCall(
           ttlMs,
           overagePolicy,
           unit,
+          userId: state.resolvedUserId,
+          sessionId: state.resolvedSessionId,
         });
         if (isAllowed(retry.decision)) {
-          totalReservationsMade++;
+          state.totalReservationsMade++;
           if (retry.reservationId) {
-            activeReservations.set(event.toolCallId, {
+            state.activeReservations.set(event.toolCallId, {
               reservationId: retry.reservationId,
               estimate,
               toolName,
@@ -857,14 +912,14 @@ export async function beforeToolCall(
               kind: "tool",
               currency: unit,
             });
-            startHeartbeat(event.toolCallId, retry.reservationId);
+            startHeartbeat(state, event.toolCallId, retry.reservationId);
           }
-          toolCallCounts.set(toolName, (toolCallCounts.get(toolName) ?? 0) + 1);
+          state.toolCallCounts.set(toolName, (state.toolCallCounts.get(toolName) ?? 0) + 1);
           if (snapshot.level === "low" && config.lowBudgetStrategies.includes("limit_remaining_calls")) {
-            remainingCallsAllowed--;
+            state.remainingCallsAllowed--;
           }
-          invalidateSnapshotCache();
-          logEvent({ timestamp: Date.now(), hook: "before_tool_call", action: "reserve", kind: "tool", name: toolName, amount: estimate, decision: retry.decision, reason: "retry_success", budgetLevel: snapshot.level, remaining: snapshot.remaining });
+          invalidateSnapshotCache(state);
+          logEvent(state, { timestamp: Date.now(), hook: "before_tool_call", action: "reserve", kind: "tool", name: toolName, amount: estimate, decision: retry.decision, reason: "retry_success", budgetLevel: snapshot.level, remaining: snapshot.remaining });
           return undefined;
         }
       }
@@ -874,19 +929,19 @@ export async function beforeToolCall(
       `Tool "${toolName}" denied by Cycles (decision=${result.decision}, reason=${result.reasonCode ?? "none"})`,
     );
     emitCounter("cycles.reservation.denied", 1, { kind: "tool", name: toolName, reason: result.reasonCode ?? "denied" });
-    logEvent({ timestamp: Date.now(), hook: "before_tool_call", action: "deny", kind: "tool", name: toolName, decision: result.decision, reason: result.reasonCode, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+    logEvent(state, { timestamp: Date.now(), hook: "before_tool_call", action: "deny", kind: "tool", name: toolName, decision: result.decision, reason: result.reasonCode, budgetLevel: snapshot.level, remaining: snapshot.remaining });
     return {
       block: true,
       blockReason: `Budget reservation denied for tool "${toolName}": ${result.reasonCode ?? "budget limit reached"}`,
     };
   }
 
-  totalReservationsMade++;
+  state.totalReservationsMade++;
   emitCounter("cycles.reservation.created", 1, { kind: "tool", name: toolName });
   logger.info(`Tool reserved: ${toolName} (estimate=${estimate}, remaining=${snapshot.remaining})`);
 
   if (result.reservationId) {
-    activeReservations.set(event.toolCallId, {
+    state.activeReservations.set(event.toolCallId, {
       reservationId: result.reservationId,
       estimate,
       toolName,
@@ -898,22 +953,22 @@ export async function beforeToolCall(
 
   // v0.6.0: Start heartbeat for long-running tool reservations
   if (result.reservationId) {
-    startHeartbeat(event.toolCallId, result.reservationId);
+    startHeartbeat(state, event.toolCallId, result.reservationId);
   }
 
   // Track per-tool invocation count for toolCallLimits
-  toolCallCounts.set(toolName, (toolCallCounts.get(toolName) ?? 0) + 1);
+  state.toolCallCounts.set(toolName, (state.toolCallCounts.get(toolName) ?? 0) + 1);
 
   // Gap 13: Decrement remaining calls counter
   if (snapshot.level === "low" && config.lowBudgetStrategies.includes("limit_remaining_calls")) {
-    remainingCallsAllowed--;
+    state.remainingCallsAllowed--;
   }
 
-  invalidateSnapshotCache();
+  invalidateSnapshotCache(state);
 
-  logEvent({ timestamp: Date.now(), hook: "before_tool_call", action: "reserve", kind: "tool", name: toolName, amount: estimate, decision: result.decision, budgetLevel: snapshot.level, remaining: snapshot.remaining });
-  checkBurnRate(snapshot.remaining);
-  checkExhaustionForecast(snapshot.remaining);
+  logEvent(state, { timestamp: Date.now(), hook: "before_tool_call", action: "reserve", kind: "tool", name: toolName, amount: estimate, decision: result.decision, budgetLevel: snapshot.level, remaining: snapshot.remaining });
+  checkBurnRate(state, snapshot.remaining);
+  checkExhaustionForecast(state, snapshot.remaining);
 
   return undefined;
 }
@@ -924,9 +979,10 @@ export async function beforeToolCall(
 
 export async function afterToolCall(
   event: ToolResultEvent,
-  _ctx: HookContext,
+  ctx: HookContext,
 ): Promise<void> {
-  const reservation = activeReservations.get(event.toolCallId);
+  const { state } = getSessionState(event, ctx);
+  const reservation = state.activeReservations.get(event.toolCallId);
   if (!reservation) {
     logger.debug(
       `after_tool_call: no active reservation for callId=${event.toolCallId}`,
@@ -934,7 +990,7 @@ export async function afterToolCall(
     return;
   }
 
-  stopHeartbeat(event.toolCallId);
+  stopHeartbeat(state, event.toolCallId);
 
   // Gap 2: Use cost estimator if available, otherwise use estimate
   let actual = reservation.estimate;
@@ -956,25 +1012,25 @@ export async function afterToolCall(
   await commitUsage(client, reservation.reservationId, actual, unit, logger);
   // Delete from tracking AFTER commit (not before) so orphaned reservations
   // can be released at agentEnd if commit fails
-  activeReservations.delete(event.toolCallId);
+  state.activeReservations.delete(event.toolCallId);
   logger.info(`Tool committed: ${reservation.toolName} (cost=${actual} ${unit})`);
 
   // Gap 6 & 9: Track tool cost
-  trackCost(`tool:${reservation.toolName}`, actual);
-  totalToolCost += actual;
-  totalToolCalls++;
+  trackCost(state, `tool:${reservation.toolName}`, actual);
+  state.totalToolCost += actual;
+  state.totalToolCalls++;
 
   // v0.5.0: Emit commit metrics
   emitCounter("cycles.reservation.committed", 1, { kind: "tool", name: reservation.toolName });
   emitHistogram("cycles.reservation.cost", actual, { kind: "tool", name: reservation.toolName });
 
-  logEvent({ timestamp: Date.now(), hook: "after_tool_call", action: "commit", kind: "tool", name: reservation.toolName, amount: actual, budgetLevel: cachedSnapshot?.level ?? "healthy", remaining: cachedSnapshot?.remaining ?? 0 });
+  logEvent(state, { timestamp: Date.now(), hook: "after_tool_call", action: "commit", kind: "tool", name: reservation.toolName, amount: actual, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
 
-  invalidateSnapshotCache();
+  invalidateSnapshotCache(state);
 
   // v0.5.0: Aggressive cache invalidation — proactively refetch after mutation
   if (config.aggressiveCacheInvalidation) {
-    await getSnapshot();
+    await getSnapshot(state);
   }
 }
 
@@ -983,126 +1039,133 @@ export async function afterToolCall(
 // ---------------------------------------------------------------------------
 
 export async function agentEnd(
-  _event: AgentEndEvent,
+  event: AgentEndEvent,
   ctx: HookContext,
 ): Promise<void> {
-  // v0.5.0: Commit any pending model reservation from the last turn.
-  // If commit fails, release the reservation so budget isn't locked until TTL.
-  if (pendingModelReservation) {
-    const resId = pendingModelReservation.reservationId;
-    try {
-      await commitPendingModelReservation();
-    } catch (err) {
-      logger.warn(`Failed to commit pending model reservation ${resId} at agent_end, releasing:`, err);
-      await releaseReservation(client, resId, "commit_failed_at_agent_end", logger);
+  const { key, state } = getSessionState(event, ctx);
+  try {
+    // v0.5.0: Commit any pending model reservation from the last turn.
+    // If commit fails, release the reservation so budget isn't locked until TTL.
+    if (state.pendingModelReservation) {
+      const resId = state.pendingModelReservation.reservationId;
+      try {
+        await commitPendingModelReservation(state);
+      } catch (err) {
+        logger.warn(`Failed to commit pending model reservation ${resId} at agent_end, releasing:`, err);
+        await releaseReservation(client, resId, "commit_failed_at_agent_end", logger);
+      }
     }
-  }
 
-  // v0.6.0: Stop all heartbeat timers
-  for (const timer of heartbeatTimers.values()) clearInterval(timer);
-  heartbeatTimers.clear();
+    // v0.6.0: Stop only this session's heartbeat timers before releasing holds.
+    stopAllHeartbeats(state);
 
-  // Release any orphaned reservations
-  if (activeReservations.size > 0) {
-    logger.warn(
-      `agent_end: releasing ${activeReservations.size} orphaned reservation(s)`,
-    );
-    const orphaned = [...activeReservations.values()];
-    for (const r of orphaned) {
-      logEvent({ timestamp: Date.now(), hook: "agent_end", action: "release", kind: r.kind, name: r.toolName, amount: r.estimate, budgetLevel: cachedSnapshot?.level ?? "healthy", remaining: cachedSnapshot?.remaining ?? 0 });
+    // Release any orphaned reservations belonging to this session only.
+    if (state.activeReservations.size > 0) {
+      logger.warn(
+        `agent_end: releasing ${state.activeReservations.size} orphaned reservation(s)`,
+      );
+      const orphaned = [...state.activeReservations.values()];
+      for (const r of orphaned) {
+        logEvent(state, { timestamp: Date.now(), hook: "agent_end", action: "release", kind: r.kind, name: r.toolName, amount: r.estimate, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
+      }
+      const releases = orphaned.map((r) =>
+        releaseReservation(client, r.reservationId, "agent_end_cleanup", logger),
+      );
+      await Promise.allSettled(releases);
+      state.activeReservations.clear();
     }
-    const releases = orphaned.map((r) =>
-      releaseReservation(client, r.reservationId, "agent_end_cleanup", logger),
-    );
-    await Promise.allSettled(releases);
-    activeReservations.clear();
-  }
 
-  // Fetch final budget state for summary
-  invalidateSnapshotCache();
-  const snapshot = await getSnapshot(ctx);
+    // Fetch final budget state for summary
+    invalidateSnapshotCache(state);
+    const snapshot = await getSnapshot(state);
 
-  // Gap 6: Build cost breakdown as plain object
-  const breakdown: Record<string, { count: number; totalCost: number }> = {};
-  for (const [key, value] of costBreakdown) {
-    breakdown[key] = { count: value.count, totalCost: value.totalCost };
-  }
+    // Gap 6: Build cost breakdown as plain object
+    const breakdown: Record<string, { count: number; totalCost: number }> = {};
+    for (const [breakdownKey, value] of state.costBreakdown) {
+      breakdown[breakdownKey] = { count: value.count, totalCost: value.totalCost };
+    }
 
-  // Gap 9: Include forecast data
-  const forecast = buildForecast();
+    // Gap 9: Include forecast data
+    const forecast = buildForecast(state);
 
-  // Build per-tool call counts as plain object
-  const callCounts: Record<string, number> = {};
-  for (const [key, value] of toolCallCounts) {
-    callCounts[key] = value;
-  }
+    // Build per-tool call counts as plain object
+    const callCounts: Record<string, number> = {};
+    for (const [toolName, value] of state.toolCallCounts) {
+      callCounts[toolName] = value;
+    }
 
-  // v0.6.0: Build unconfigured tools report
-  const unconfiguredTools = [...warnedUnconfiguredTools].map((name) => ({
-    name,
-    callCount: callCounts[name] ?? 0,
-    estimatedTotalCost: (callCounts[name] ?? 0) * DEFAULT_TOOL_COST,
-  }));
+    // v0.6.0: Build unconfigured tools report
+    const unconfiguredTools = [...state.warnedUnconfiguredTools].map((name) => ({
+      name,
+      callCount: callCounts[name] ?? 0,
+      estimatedTotalCost: (callCounts[name] ?? 0) * DEFAULT_TOOL_COST,
+    }));
 
-  const summary: SessionSummary = {
-    tenant: config.tenant,
-    budgetId: config.budgetId,
-    budgetScope: config.budgetScope,
-    userId: resolvedUserId,
-    sessionId: resolvedSessionId,
-    remaining: snapshot.remaining,
-    spent: snapshot.spent,
-    reserved: snapshot.reserved,
-    allocated: snapshot.allocated,
-    level: snapshot.level,
-    totalReservationsMade,
-    costBreakdown: breakdown,
-    toolCallCounts: callCounts,
-    startedAt: sessionStartedAt,
-    endedAt: Date.now(),
-    unconfiguredTools: unconfiguredTools.length > 0 ? unconfiguredTools : undefined,
-    eventLog: config.enableEventLog ? [...eventLog] : undefined,
-  };
-
-  logger.info(`Agent session budget summary: remaining=${summary.remaining} spent=${summary.spent} reservations=${summary.totalReservationsMade}`);
-
-  // Attach to context metadata if available
-  if (ctx.metadata) {
-    ctx.metadata["openclaw-budget-guard"] = {
-      ...summary,
-      avgToolCost: forecast.avgToolCost,
-      avgModelCost: forecast.avgModelCost,
-      estimatedRemainingToolCalls:
-        forecast.avgToolCost > 0 ? Math.floor(snapshot.remaining / forecast.avgToolCost) : undefined,
-      estimatedRemainingModelCalls:
-        forecast.avgModelCost > 0 ? Math.floor(snapshot.remaining / forecast.avgModelCost) : undefined,
+    const summary: SessionSummary = {
+      tenant: config.tenant,
+      budgetId: config.budgetId,
+      budgetScope: config.budgetScope,
+      userId: state.resolvedUserId,
+      sessionId: state.resolvedSessionId,
+      remaining: snapshot.remaining,
+      spent: snapshot.spent,
+      reserved: snapshot.reserved,
+      allocated: snapshot.allocated,
+      level: snapshot.level,
+      totalReservationsMade: state.totalReservationsMade,
+      costBreakdown: breakdown,
+      toolCallCounts: callCounts,
+      startedAt: state.sessionStartedAt,
+      endedAt: Date.now(),
+      unconfiguredTools: unconfiguredTools.length > 0 ? unconfiguredTools : undefined,
+      eventLog: config.enableEventLog ? [...state.eventLog] : undefined,
     };
-  }
 
-  // Gap 15: Cross-session analytics
-  if (config.onSessionEnd) {
-    try {
-      await config.onSessionEnd(summary);
-    } catch (err) {
-      logger.warn("onSessionEnd callback error:", err);
+    logger.info(`Agent session budget summary: remaining=${summary.remaining} spent=${summary.spent} reservations=${summary.totalReservationsMade}`);
+
+    // Attach to context metadata if available
+    if (ctx.metadata) {
+      ctx.metadata["openclaw-budget-guard"] = {
+        ...summary,
+        avgToolCost: forecast.avgToolCost,
+        avgModelCost: forecast.avgModelCost,
+        estimatedRemainingToolCalls:
+          forecast.avgToolCost > 0 ? Math.floor(snapshot.remaining / forecast.avgToolCost) : undefined,
+        estimatedRemainingModelCalls:
+          forecast.avgModelCost > 0 ? Math.floor(snapshot.remaining / forecast.avgModelCost) : undefined,
+      };
     }
-  }
-  if (config.analyticsWebhookUrl) {
-    fireWebhook(config.analyticsWebhookUrl, summary);
-  }
 
-  // v0.5.0: Emit session-level metrics
-  const durationMs = summary.endedAt - summary.startedAt;
-  emitHistogram("cycles.session.duration_ms", durationMs);
-  const totalCost = [...costBreakdown.values()].reduce((sum, e) => sum + e.totalCost, 0);
-  emitHistogram("cycles.session.total_cost", totalCost);
-
-  // v0.7.10: Flush metrics emitter to ensure all datapoints are sent
-  if (metricsEmitter?.flush) {
-    try {
-      await metricsEmitter.flush();
-    } catch {
-      // Best-effort — metrics flush failure is non-fatal
+    // Gap 15: Cross-session analytics
+    if (config.onSessionEnd) {
+      try {
+        await config.onSessionEnd(summary);
+      } catch (err) {
+        logger.warn("onSessionEnd callback error:", err);
+      }
     }
+    if (config.analyticsWebhookUrl) {
+      fireWebhook(config.analyticsWebhookUrl, summary);
+    }
+
+    // v0.5.0: Emit session-level metrics
+    const durationMs = summary.endedAt - summary.startedAt;
+    emitHistogram("cycles.session.duration_ms", durationMs);
+    const totalCost = [...state.costBreakdown.values()].reduce((sum, e) => sum + e.totalCost, 0);
+    emitHistogram("cycles.session.total_cost", totalCost);
+
+    // v0.7.10: Flush metrics emitter to ensure all datapoints are sent
+    if (metricsEmitter?.flush) {
+      try {
+        await metricsEmitter.flush();
+      } catch {
+        // Best-effort — metrics flush failure is non-fatal
+      }
+    }
+  } finally {
+    // Never allow a timer or completed session state to survive agent_end,
+    // including callback, metrics, snapshot, commit, or release error paths.
+    stopAllHeartbeats(state);
+    if (sessionStates.get(key) === state) sessionStates.delete(key);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,14 +7,7 @@
  */
 
 import { resolveConfig } from "./config.js";
-import {
-  initHooks,
-  beforeModelResolve,
-  beforePromptBuild,
-  beforeToolCall,
-  afterToolCall,
-  agentEnd,
-} from "./hooks.js";
+import { createHooks } from "./hooks.js";
 import { createOtlpEmitter } from "./metrics-otlp.js";
 import { wrapLogger } from "./logger.js";
 import { PLUGIN_VERSION } from "./version.js";
@@ -252,29 +245,29 @@ export default function (api: OpenClawPluginApi): void {
     );
   }
 
-  initHooks(config, wrapLogger(api.logger, config.logLevel));
+  const hooks = createHooks(config, wrapLogger(api.logger, config.logLevel));
 
-  api.on("before_model_resolve", beforeModelResolve, {
+  api.on("before_model_resolve", hooks.beforeModelResolve, {
     name: "openclaw-budget-guard:before_model_resolve",
     priority: 10,
   });
 
-  api.on("before_prompt_build", beforePromptBuild, {
+  api.on("before_prompt_build", hooks.beforePromptBuild, {
     name: "openclaw-budget-guard:before_prompt_build",
     priority: 10,
   });
 
-  api.on("before_tool_call", beforeToolCall, {
+  api.on("before_tool_call", hooks.beforeToolCall, {
     name: "openclaw-budget-guard:before_tool_call",
     priority: 10,
   });
 
-  api.on("after_tool_call", afterToolCall, {
+  api.on("after_tool_call", hooks.afterToolCall, {
     name: "openclaw-budget-guard:after_tool_call",
     priority: 10,
   });
 
-  api.on("agent_end", agentEnd, {
+  api.on("agent_end", hooks.agentEnd, {
     name: "openclaw-budget-guard:agent_end",
     priority: 100,
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -319,12 +319,14 @@ export interface OpenClawPluginApi {
 }
 
 // ---------------------------------------------------------------------------
-// OpenClaw hook event types (approximated from OpenClaw docs)
+// OpenClaw hook event types
 // ---------------------------------------------------------------------------
 
 /** Event for the before_model_resolve hook. */
 export interface ModelResolveEvent {
-  model: string;
+  /** Present on older hosts; current hosts expose the resolved model on ctx. */
+  model?: string;
+  runId?: string;
   [key: string]: unknown;
 }
 
@@ -348,6 +350,7 @@ export interface PromptBuildResult {
 export interface ToolCallEvent {
   toolName: string;
   toolCallId: string;
+  runId?: string;
   params?: Record<string, unknown>;
   [key: string]: unknown;
 }
@@ -363,6 +366,7 @@ export interface ToolCallResult {
 export interface ToolResultEvent {
   toolName: string;
   toolCallId: string;
+  runId?: string;
   result?: unknown;
   durationMs?: number;
   [key: string]: unknown;
@@ -370,11 +374,24 @@ export interface ToolResultEvent {
 
 /** Event for the agent_end hook. */
 export interface AgentEndEvent {
+  runId?: string;
   [key: string]: unknown;
 }
 
 /** Context object available in hook handlers. */
 export interface HookContext {
+  /** Stable physical session UUID supplied by current OpenClaw hosts. */
+  sessionId?: string;
+  /** Stable logical session key supplied by current OpenClaw hosts. */
+  sessionKey?: string;
+  /** Per-agent-run identifier, used when no session identifier is available. */
+  runId?: string;
+  agentId?: string;
+  modelProviderId?: string;
+  modelId?: string;
+  /** Compatibility fallback used by some older/custom hosts. */
+  conversationId?: string;
+  /** Legacy/custom context metadata retained for compatibility. */
   metadata?: Record<string, unknown>;
   [key: string]: unknown;
 }

--- a/tests/cycles.test.ts
+++ b/tests/cycles.test.ts
@@ -850,10 +850,10 @@ describe("commitUsage", () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it("does not throw on API error", async () => {
+  it("returns false without throwing on a transient 503", async () => {
     mockCommitReservation.mockResolvedValue({
       isSuccess: false,
-      status: 500,
+      status: 503,
     });
 
     const client = createCyclesClient(makeConfig());

--- a/tests/cycles.test.ts
+++ b/tests/cycles.test.ts
@@ -841,7 +841,8 @@ describe("commitUsage", () => {
     });
 
     const client = createCyclesClient(makeConfig());
-    await commitUsage(client, "res-ok", 500_000, "USD_MICROCENTS", logger);
+    const committed = await commitUsage(client, "res-ok", 500_000, "USD_MICROCENTS", logger);
+    expect(committed).toBe(true);
     expect(mockCommitReservation).toHaveBeenCalledWith("res-ok", {
       idempotency_key: "test-uuid-1234",
       actual: { unit: "USD_MICROCENTS", amount: 500_000 },
@@ -858,7 +859,7 @@ describe("commitUsage", () => {
     const client = createCyclesClient(makeConfig());
     await expect(
       commitUsage(client, "res-1", 500_000, "USD_MICROCENTS", logger),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(false);
     expect(logger.warn).toHaveBeenCalled();
   });
 
@@ -868,7 +869,7 @@ describe("commitUsage", () => {
     const client = createCyclesClient(makeConfig());
     await expect(
       commitUsage(client, "res-1", 500_000, "USD_MICROCENTS", logger),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(false);
     expect(logger.warn).toHaveBeenCalled();
   });
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -50,6 +50,7 @@ const mockFetch = vi.fn(() => Promise.resolve({ ok: true }));
 vi.stubGlobal("fetch", mockFetch);
 
 import {
+  createHooks,
   initHooks,
   _resetInitialized,
   beforeModelResolve,
@@ -71,6 +72,7 @@ function setup(configOverrides?: Parameters<typeof makeConfig>[0]) {
 
 describe("initHooks", () => {
   beforeEach(() => {
+    _resetInitialized();
     vi.clearAllMocks();
   });
 
@@ -142,6 +144,16 @@ describe("initHooks", () => {
       expect.stringContaining("[DRY-RUN]"),
     );
   });
+
+  it("does not replace the dry-run reservation store on repeated legacy init", async () => {
+    const { DryRunClient } = await import("../src/dry-run.js");
+    const config = makeConfig({ dryRun: true, dryRunBudget: 50_000_000 });
+
+    initHooks(config, makeLogger());
+    initHooks(config, makeLogger());
+
+    expect(DryRunClient).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("beforeModelResolve — snapshot caching", () => {
@@ -172,11 +184,9 @@ describe("beforeModelResolve — snapshot caching", () => {
     vi.advanceTimersByTime(3000);
     await beforeModelResolve({ model: "gpt-4o" }, makeHookContext());
 
-    // Each beforeModelResolve call triggers a fetch because model reservation
-    // invalidates the cache after commit. The second call also commits the
-    // pending model reservation from turn 1, which triggers an aggressive
-    // cache refetch.
-    expect(mockFetchBudgetState).toHaveBeenCalledTimes(3);
+    // The second call commits before reading the snapshot. Its aggressive
+    // refetch satisfies that call's snapshot read, avoiding a duplicate fetch.
+    expect(mockFetchBudgetState).toHaveBeenCalledTimes(2);
   });
 
   it("re-fetches with configurable cache TTL after invalidation", async () => {
@@ -190,8 +200,8 @@ describe("beforeModelResolve — snapshot caching", () => {
     vi.advanceTimersByTime(1500); // > 1s custom TTL
     await beforeModelResolve({ model: "gpt-4o" }, makeHookContext());
 
-    // 3 calls: first resolve, aggressive refetch after pending commit, second resolve
-    expect(mockFetchBudgetState).toHaveBeenCalledTimes(3);
+    // First resolve + the second resolve's aggressive post-commit refetch.
+    expect(mockFetchBudgetState).toHaveBeenCalledTimes(2);
   });
 
   afterEach(() => {
@@ -2858,7 +2868,7 @@ describe("concurrent session isolation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    mockCommitUsage.mockResolvedValue(undefined);
+    mockCommitUsage.mockResolvedValue(true);
     mockReleaseReservation.mockResolvedValue(undefined);
     mockCreateCyclesClient.mockReturnValue({ extendReservation: mockExtendReservation });
     mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "healthy" }));
@@ -2958,9 +2968,8 @@ describe("concurrent session isolation", () => {
       }),
     );
     mockCommitUsage.mockImplementation(
-      (_client: unknown, reservationId: string) => reservationId === "error-tool-a"
-        ? Promise.reject(new Error("commit failed"))
-        : Promise.resolve(undefined),
+      (_client: unknown, reservationId: string) =>
+        Promise.resolve(reservationId !== "error-tool-a"),
     );
 
     await beforeToolCall({ toolName: "tool-a", toolCallId: "same-id" }, sessionA);
@@ -2968,7 +2977,7 @@ describe("concurrent session isolation", () => {
 
     await expect(
       afterToolCall({ toolName: "tool-a", toolCallId: "same-id", error: "failed" }, sessionA),
-    ).rejects.toThrow("commit failed");
+    ).resolves.toBeUndefined();
 
     // A's timer stopped on the error path; B's timer is still alive.
     mockExtendReservation.mockClear();
@@ -2989,6 +2998,113 @@ describe("concurrent session isolation", () => {
     expect(mockExtendReservation).not.toHaveBeenCalled();
     await agentEnd({ runId: "run-b", success: true }, sessionB);
     expect(mockReleaseReservation.mock.calls.map((call) => call[1])).toEqual(["error-tool-a"]);
+  });
+
+  it("isolates clients, pending models, costs, releases, and timers across registrations", async () => {
+    const extendA = vi.fn().mockResolvedValue({});
+    const extendB = vi.fn().mockResolvedValue({});
+    const clientA = { runtime: "a", extendReservation: extendA };
+    const clientB = { runtime: "b", extendReservation: extendB };
+    const metricsA = { gauge: vi.fn(), counter: vi.fn(), histogram: vi.fn() };
+    const metricsB = { gauge: vi.fn(), counter: vi.fn(), histogram: vi.fn() };
+    mockCreateCyclesClient
+      .mockReturnValueOnce(clientA)
+      .mockReturnValueOnce(clientB);
+
+    const summariesA: SessionSummary[] = [];
+    const summariesB: SessionSummary[] = [];
+    const hooksA = createHooks(makeConfig({
+      tenant: "tenant-a",
+      heartbeatIntervalMs: 1_000,
+      aggressiveCacheInvalidation: false,
+      injectPromptBudgetHint: false,
+      modelBaseCosts: { shared: 1_000 },
+      toolBaseCosts: { shared: 100 },
+      metricsEmitter: metricsA,
+      onSessionEnd: (summary) => { summariesA.push(summary); },
+    }), makeLogger());
+    const hooksB = createHooks(makeConfig({
+      tenant: "tenant-b",
+      heartbeatIntervalMs: 1_000,
+      aggressiveCacheInvalidation: false,
+      injectPromptBudgetHint: false,
+      modelBaseCosts: { shared: 2_000 },
+      toolBaseCosts: { shared: 200 },
+      metricsEmitter: metricsB,
+      onSessionEnd: (summary) => { summariesB.push(summary); },
+    }), makeLogger());
+
+    mockReserveBudget.mockImplementation(
+      (_client: unknown, config: { tenant: string }, request: { actionName: string; actionKind: string }) =>
+        Promise.resolve({
+          decision: "ALLOW",
+          reservationId: `${config.tenant}-${request.actionKind}-${request.actionName}`,
+          affectedScopes: [],
+        }),
+    );
+    mockCommitUsage.mockImplementation(
+      (_client: unknown, reservationId: string) =>
+        Promise.resolve(reservationId !== "tenant-b-tool.shared-shared"),
+    );
+
+    // The host identity and call ID deliberately collide. Registration
+    // ownership must still keep these tenants entirely separate.
+    const sharedContext = { sessionId: "same-session", metadata: {} };
+    await hooksA.beforeModelResolve({ model: "shared" }, sharedContext);
+    await hooksB.beforeModelResolve({ model: "shared" }, sharedContext);
+    await hooksA.beforeToolCall({ toolName: "shared", toolCallId: "same-call" }, sharedContext);
+    await hooksB.beforeToolCall({ toolName: "shared", toolCallId: "same-call" }, sharedContext);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(extendA).toHaveBeenCalledWith("tenant-a-tool.shared-shared", expect.anything());
+    expect(extendB).toHaveBeenCalledWith("tenant-b-tool.shared-shared", expect.anything());
+
+    mockCommitUsage.mockClear();
+    await hooksB.beforePromptBuild({}, sharedContext);
+    await hooksA.beforePromptBuild({}, sharedContext);
+    expect(mockCommitUsage.mock.calls.slice(0, 2).map((call) => [call[0], call[1]])).toEqual([
+      [clientB, "tenant-b-llm.completion-shared"],
+      [clientA, "tenant-a-llm.completion-shared"],
+    ]);
+
+    await hooksA.afterToolCall({ toolName: "shared", toolCallId: "same-call" }, sharedContext);
+    await hooksB.afterToolCall({ toolName: "shared", toolCallId: "same-call", error: "commit failed" }, sharedContext);
+
+    extendA.mockClear();
+    extendB.mockClear();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(extendA).not.toHaveBeenCalled();
+    expect(extendB).not.toHaveBeenCalled();
+
+    await hooksA.agentEnd({}, sharedContext);
+    expect(mockReleaseReservation).not.toHaveBeenCalled();
+    await hooksB.agentEnd({}, sharedContext);
+    expect(mockReleaseReservation).toHaveBeenCalledWith(
+      clientB,
+      "tenant-b-tool.shared-shared",
+      "agent_end_cleanup",
+      expect.anything(),
+    );
+    expect(mockReleaseReservation).not.toHaveBeenCalledWith(
+      clientA,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    expect(summariesA[0]?.tenant).toBe("tenant-a");
+    expect(summariesA[0]?.costBreakdown).toEqual({
+      "model:shared": { count: 1, totalCost: 1_000 },
+      "tool:shared": { count: 1, totalCost: 100 },
+    });
+    expect(summariesB[0]?.tenant).toBe("tenant-b");
+    expect(summariesB[0]?.costBreakdown).toEqual({
+      "model:shared": { count: 1, totalCost: 2_000 },
+    });
+    expect(metricsA.counter).toHaveBeenCalled();
+    expect(metricsB.counter).toHaveBeenCalled();
+    expect(metricsA.counter.mock.calls.every((call) => call[2]?.tenant === "tenant-a")).toBe(true);
+    expect(metricsB.counter.mock.calls.every((call) => call[2]?.tenant === "tenant-b")).toBe(true);
   });
 });
 
@@ -3184,14 +3300,39 @@ describe("v0.7.10 — model reservation release on commit failure", () => {
     mockIsAllowed.mockReturnValue(true);
     // Reserve succeeds, but commit will fail
     mockReserveBudget.mockResolvedValue({ decision: "ALLOW", reservationId: "model-r1", affectedScopes: [] });
-    mockCommitUsage
-      .mockRejectedValueOnce(new Error("commit failed")) // first commit in agentEnd fails
-      .mockResolvedValue(undefined); // subsequent commits ok
+    mockCommitUsage.mockResolvedValue(false);
 
     await beforeModelResolve({ model: "gpt-4o" }, makeHookContext());
     // Now there's a pending model reservation — agentEnd should try to commit, fail, then release
     await agentEnd({}, makeHookContext());
 
+    expect(mockReleaseReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      "model-r1",
+      "commit_failed_at_agent_end",
+      expect.anything(),
+    );
+  });
+
+  it("does not create a second model hold when the pending commit fails", async () => {
+    setup({ aggressiveCacheInvalidation: false });
+    mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "healthy" }));
+    mockIsAllowed.mockReturnValue(true);
+    mockReserveBudget.mockResolvedValue({
+      decision: "ALLOW",
+      reservationId: "model-r1",
+      affectedScopes: [],
+    });
+
+    await beforeModelResolve({ model: "gpt-4o" }, makeHookContext());
+    mockCommitUsage.mockResolvedValue(false);
+
+    await expect(
+      beforeModelResolve({ model: "gpt-4o" }, makeHookContext()),
+    ).rejects.toThrow("Failed to commit model reservation model-r1");
+    expect(mockReserveBudget).toHaveBeenCalledTimes(1);
+
+    await agentEnd({}, makeHookContext());
     expect(mockReleaseReservation).toHaveBeenCalledWith(
       expect.anything(),
       "model-r1",

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { makeConfig, makeLogger, makeSnapshot, makeHookContext } from "./helpers.js";
-import type { BudgetSnapshot } from "../src/types.js";
+import type { BudgetSnapshot, SessionSummary } from "../src/types.js";
 import { BudgetExhaustedError } from "../src/types.js";
 
 // --- Mocks ---
@@ -1206,6 +1206,11 @@ describe("beforeToolCall resolves userId/sessionId from ctx", () => {
     // The snapshot fetch should use the ctx-overridden values
     expect(mockFetchBudgetState).toHaveBeenCalledWith(
       expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ userId: "ctx-user", sessionId: "ctx-session" }),
+    );
+    expect(mockReserveBudget).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       expect.objectContaining({ userId: "ctx-user", sessionId: "ctx-session" }),
@@ -2828,6 +2833,162 @@ describe("v0.6.0 — reservation heartbeat", () => {
     mockExtendReservation.mockClear();
     await vi.advanceTimersByTimeAsync(30_000);
     expect(mockExtendReservation).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent session isolation
+// ---------------------------------------------------------------------------
+
+describe("concurrent session isolation", () => {
+  const mockExtendReservation = vi.fn().mockResolvedValue({});
+  const sessionA = {
+    sessionId: "session-a",
+    sessionKey: "agent:a",
+    runId: "run-a",
+    metadata: {},
+  };
+  const sessionB = {
+    sessionId: "session-b",
+    sessionKey: "agent:b",
+    runId: "run-b",
+    metadata: {},
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockCommitUsage.mockResolvedValue(undefined);
+    mockReleaseReservation.mockResolvedValue(undefined);
+    mockCreateCyclesClient.mockReturnValue({ extendReservation: mockExtendReservation });
+    mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "healthy" }));
+    mockIsAllowed.mockReturnValue(true);
+    mockIsToolPermitted.mockReturnValue({ permitted: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps pending models, tool reservations, costs, and heartbeats isolated", async () => {
+    const summaries: SessionSummary[] = [];
+    setup({
+      heartbeatIntervalMs: 1_000,
+      aggressiveCacheInvalidation: false,
+      injectPromptBudgetHint: false,
+      modelBaseCosts: { "model-a": 1_000, "model-b": 2_000 },
+      toolBaseCosts: { "tool-a": 100, "tool-b": 200 },
+      onSessionEnd: (summary) => {
+        summaries.push(summary);
+      },
+    });
+    mockReserveBudget.mockImplementation(
+      (_client: unknown, _config: unknown, request: { actionName: string }) => Promise.resolve({
+        decision: "ALLOW",
+        reservationId: `reservation-${request.actionName}`,
+        affectedScopes: [],
+      }),
+    );
+
+    // Interleave two complete lifecycles. Reusing the same toolCallId is
+    // intentional: call IDs are only required to be unique within a session.
+    await beforeModelResolve({ model: "model-a" }, sessionA);
+    await beforeModelResolve({ model: "model-b" }, sessionB);
+    await beforeToolCall({ toolName: "tool-a", toolCallId: "shared-call" }, sessionA);
+    await beforeToolCall({ toolName: "tool-b", toolCallId: "shared-call" }, sessionB);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mockExtendReservation.mock.calls.map((call) => call[0]).sort()).toEqual([
+      "reservation-tool-a",
+      "reservation-tool-b",
+    ]);
+
+    await afterToolCall({ toolName: "tool-a", toolCallId: "shared-call" }, sessionA);
+    mockExtendReservation.mockClear();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mockExtendReservation).toHaveBeenCalledTimes(1);
+    expect(mockExtendReservation).toHaveBeenCalledWith(
+      "reservation-tool-b",
+      expect.anything(),
+    );
+
+    // Committing B's pending model must never consume A's pending slot.
+    mockCommitUsage.mockClear();
+    await beforePromptBuild({}, sessionB);
+    expect(mockCommitUsage.mock.calls.map((call) => call[1])).toEqual(["reservation-model-b"]);
+
+    // B ends with an orphaned tool. Its cleanup must release only B's hold.
+    await agentEnd({ runId: "run-b" }, sessionB);
+    expect(mockReleaseReservation.mock.calls.map((call) => call[1])).toEqual(["reservation-tool-b"]);
+    mockExtendReservation.mockClear();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(mockExtendReservation).not.toHaveBeenCalled();
+
+    // A's model is still pending and remains independently committable.
+    mockCommitUsage.mockClear();
+    await beforePromptBuild({}, sessionA);
+    expect(mockCommitUsage.mock.calls.map((call) => call[1])).toEqual(["reservation-model-a"]);
+    await agentEnd({ runId: "run-a" }, sessionA);
+
+    expect(summaries).toHaveLength(2);
+    const summaryA = summaries.find((summary) => summary.sessionId === "session-a");
+    const summaryB = summaries.find((summary) => summary.sessionId === "session-b");
+    expect(summaryA?.costBreakdown).toEqual({
+      "tool:tool-a": { count: 1, totalCost: 100 },
+      "model:model-a": { count: 1, totalCost: 1_000 },
+    });
+    expect(summaryB?.costBreakdown).toEqual({
+      "model:model-b": { count: 1, totalCost: 2_000 },
+    });
+    expect(summaryA?.toolCallCounts).toEqual({ "tool-a": 1 });
+    expect(summaryB?.toolCallCounts).toEqual({ "tool-b": 1 });
+  });
+
+  it("cleans up only the failing session heartbeat and releases its orphan", async () => {
+    setup({
+      heartbeatIntervalMs: 1_000,
+      aggressiveCacheInvalidation: false,
+      toolBaseCosts: { "tool-a": 100, "tool-b": 200 },
+    });
+    mockReserveBudget.mockImplementation(
+      (_client: unknown, _config: unknown, request: { actionName: string }) => Promise.resolve({
+        decision: "ALLOW",
+        reservationId: `error-${request.actionName}`,
+        affectedScopes: [],
+      }),
+    );
+    mockCommitUsage.mockImplementation(
+      (_client: unknown, reservationId: string) => reservationId === "error-tool-a"
+        ? Promise.reject(new Error("commit failed"))
+        : Promise.resolve(undefined),
+    );
+
+    await beforeToolCall({ toolName: "tool-a", toolCallId: "same-id" }, sessionA);
+    await beforeToolCall({ toolName: "tool-b", toolCallId: "same-id" }, sessionB);
+
+    await expect(
+      afterToolCall({ toolName: "tool-a", toolCallId: "same-id", error: "failed" }, sessionA),
+    ).rejects.toThrow("commit failed");
+
+    // A's timer stopped on the error path; B's timer is still alive.
+    mockExtendReservation.mockClear();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mockExtendReservation.mock.calls.map((call) => call[0])).toEqual(["error-tool-b"]);
+
+    await agentEnd({ runId: "run-a", success: false }, sessionA);
+    expect(mockReleaseReservation.mock.calls.map((call) => call[1])).toEqual(["error-tool-a"]);
+
+    // Ending A must not stop or release B's reservation.
+    mockExtendReservation.mockClear();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mockExtendReservation.mock.calls.map((call) => call[0])).toEqual(["error-tool-b"]);
+
+    await afterToolCall({ toolName: "tool-b", toolCallId: "same-id" }, sessionB);
+    mockExtendReservation.mockClear();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(mockExtendReservation).not.toHaveBeenCalled();
+    await agentEnd({ runId: "run-b", success: true }, sessionB);
+    expect(mockReleaseReservation.mock.calls.map((call) => call[1])).toEqual(["error-tool-a"]);
   });
 });
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -53,6 +53,7 @@ import {
   createHooks,
   initHooks,
   _resetInitialized,
+  _getDefaultSessionStateCount,
   beforeModelResolve,
   beforePromptBuild,
   beforeToolCall,
@@ -3315,7 +3316,8 @@ describe("v0.7.10 — model reservation release on commit failure", () => {
   });
 
   it("does not create a second model hold when the pending commit fails", async () => {
-    setup({ aggressiveCacheInvalidation: false });
+    const modelCostEstimator = vi.fn(() => undefined);
+    setup({ aggressiveCacheInvalidation: false, modelCostEstimator });
     mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "healthy" }));
     mockIsAllowed.mockReturnValue(true);
     mockReserveBudget.mockResolvedValue({
@@ -3324,21 +3326,112 @@ describe("v0.7.10 — model reservation release on commit failure", () => {
       affectedScopes: [],
     });
 
-    await beforeModelResolve({ model: "gpt-4o" }, makeHookContext());
+    const ctx = makeHookContext();
+    await beforeModelResolve({ model: "gpt-4o" }, ctx);
     mockCommitUsage.mockResolvedValue(false);
 
     await expect(
-      beforeModelResolve({ model: "gpt-4o" }, makeHookContext()),
-    ).rejects.toThrow("Failed to commit model reservation model-r1");
+      beforeModelResolve({ model: "gpt-4o" }, ctx),
+    ).resolves.toBeUndefined();
     expect(mockReserveBudget).toHaveBeenCalledTimes(1);
 
-    await agentEnd({}, makeHookContext());
+    await agentEnd({}, ctx);
     expect(mockReleaseReservation).toHaveBeenCalledWith(
       expect.anything(),
       "model-r1",
       "commit_failed_at_agent_end",
       expect.anything(),
     );
+    const summary = ctx.metadata!["openclaw-budget-guard"] as Record<string, unknown>;
+    expect(summary.costBreakdown).toEqual({
+      "model:gpt-4o": { count: 1, totalCost: 500_000 },
+    });
+    expect(modelCostEstimator.mock.calls.every(([call]) => call.turnIndex === 0)).toBe(true);
+  });
+
+  it("continues prompt construction when a pending model commit is deferred", async () => {
+    setup({ aggressiveCacheInvalidation: false, injectPromptBudgetHint: true });
+    mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "healthy" }));
+    mockIsAllowed.mockReturnValue(true);
+    mockReserveBudget.mockResolvedValue({
+      decision: "ALLOW",
+      reservationId: "model-r1",
+      affectedScopes: [],
+    });
+
+    const ctx = makeHookContext();
+    await beforeModelResolve({ model: "gpt-4o" }, ctx);
+    mockCommitUsage.mockResolvedValue(false);
+
+    await expect(beforePromptBuild({}, ctx)).resolves.toEqual({
+      prependSystemContext: expect.any(String),
+    });
+    await agentEnd({}, ctx);
+    expect(mockReleaseReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      "model-r1",
+      "commit_failed_at_agent_end",
+      expect.anything(),
+    );
+  });
+});
+
+describe("terminal session state cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCommitUsage.mockResolvedValue(true);
+    mockReleaseReservation.mockResolvedValue(undefined);
+    mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "healthy" }));
+    mockIsAllowed.mockReturnValue(true);
+    mockIsToolPermitted.mockReturnValue({ permitted: true });
+    mockReserveBudget.mockResolvedValue({
+      decision: "ALLOW",
+      reservationId: "tool-r1",
+      affectedScopes: [],
+    });
+  });
+
+  it("does not resurrect state for late or duplicate after_tool_call events", async () => {
+    setup({ heartbeatIntervalMs: 0, toolBaseCosts: { tool: 100 } });
+    const ctx = { sessionId: "ended-session", metadata: {} };
+
+    await beforeToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    expect(_getDefaultSessionStateCount()).toBe(1);
+    await agentEnd({}, ctx);
+    expect(_getDefaultSessionStateCount()).toBe(0);
+
+    mockCommitUsage.mockClear();
+    await afterToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    for (let i = 0; i < 50; i++) {
+      await afterToolCall(
+        { toolName: "tool", toolCallId: `late-${i}` },
+        { sessionId: `ended-session-${i}`, metadata: {} },
+      );
+    }
+
+    expect(mockCommitUsage).not.toHaveBeenCalled();
+    expect(_getDefaultSessionStateCount()).toBe(0);
+  });
+
+  it("ignores after_tool_call while agent_end is releasing the session", async () => {
+    setup({ heartbeatIntervalMs: 0, toolBaseCosts: { tool: 100 } });
+    const ctx = { sessionId: "ending-session", metadata: {} };
+    let finishRelease!: () => void;
+    mockReleaseReservation.mockImplementation(
+      () => new Promise<void>((resolve) => { finishRelease = resolve; }),
+    );
+
+    await beforeToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    const endPromise = agentEnd({}, ctx);
+    await vi.waitFor(() => expect(mockReleaseReservation).toHaveBeenCalled());
+
+    mockCommitUsage.mockClear();
+    await afterToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    expect(mockCommitUsage).not.toHaveBeenCalled();
+
+    finishRelease();
+    await endPromise;
+    expect(_getDefaultSessionStateCount()).toBe(0);
   });
 });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -27,7 +27,16 @@ vi.mock("../src/config.js", () => ({
 }));
 
 vi.mock("../src/hooks.js", () => ({
-  initHooks: (...args: unknown[]) => mockInitHooks(...args),
+  createHooks: (...args: unknown[]) => {
+    mockInitHooks(...args);
+    return {
+      beforeModelResolve: mockBeforeModelResolve,
+      beforePromptBuild: mockBeforePromptBuild,
+      beforeToolCall: mockBeforeToolCall,
+      afterToolCall: mockAfterToolCall,
+      agentEnd: mockAgentEnd,
+    };
+  },
   beforeModelResolve: mockBeforeModelResolve,
   beforePromptBuild: mockBeforePromptBuild,
   beforeToolCall: mockBeforeToolCall,
@@ -255,7 +264,7 @@ describe("plugin entrypoint", () => {
     expect(infoCall).toContain("cyclesApiKey: (not set)");
   });
 
-  it("calls initHooks with resolved config and api.logger", () => {
+  it("creates isolated hooks with resolved config and api.logger", () => {
     const resolvedConfig = makeConfig();
     mockResolveConfig.mockReturnValue(resolvedConfig);
 
@@ -286,7 +295,7 @@ describe("plugin entrypoint", () => {
     const api = { config: {}, logger, on: vi.fn() };
     registerPlugin(api);
 
-    // The wrapped logger is passed to initHooks — call it to test filtering
+    // The wrapped logger is passed to createHooks — call it to test filtering
     const wrappedLogger = mockInitHooks.mock.calls[0][1];
     wrappedLogger.debug("should be filtered");
     wrappedLogger.info("should be filtered");


### PR DESCRIPTION
## What changed

- bind every plugin registration to its own Cycles client, configuration, logger, metrics emitter, dry-run store, and session-state map
- isolate reservations, pending model holds, costs, counters, caches, event logs, forecasts, and heartbeat timers by the stable OpenClaw session/run scope within each runtime
- make commit outcomes explicit so failed tool holds remain available for `agent_end` cleanup and failed final model holds are released
- keep transient pending-model commit failures fail-open: prompt/model hooks do not reject, no second hold is created, and the subsequent model estimate is accounted locally
- fence terminal state so concurrent, late, or duplicate `after_tool_call` events cannot race cleanup or resurrect a deleted session entry
- document the host-identifier fallback limitation and commit-failure behavior

## Root cause

The hook module stored both runtime dependencies and lifecycle data in process-global singletons. Concurrent registrations could overwrite the active client/config while in-flight sessions still referenced shared reservation state, and one global pending-model slot allowed one session to clobber another.

The initial correction also exposed two follow-up lifecycle issues: expected commit non-success outcomes were converted into rejected pre-model hooks, and `after_tool_call` used a get-or-create lookup that could recreate state after `agent_end`.

## Impact

Concurrent sessions and tenants in one Node process no longer commit, attribute, extend, or release each other's reservations. A transient commit 503 remains non-blocking without orphaning or replacing the pending hold. Terminal hook delivery cannot grow the session map after cleanup. The package's public API remains unchanged.

## Validation

- `npm run test:coverage` — 380 tests passing; 98.23% statements, 95.64% branches, 99.35% functions, 98.83% lines
- `npm run typecheck`
- `npm run build`
- focused `cycles.test.ts` and `hooks.test.ts` run — 199 tests passing

Regression tests interleave two sessions and two independent tenant runtimes, deliberately reuse session/tool-call identifiers, assert client/config/pending-model/cost/metrics/release/heartbeat isolation, cover transient 503 fail-open behavior, and exercise concurrent plus post-`agent_end` delivery.