### PR TITLE
chore(ci): switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,6 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release:
     name: Create GitHub Release

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -851,3 +851,13 @@ The plugin is **production-ready and contract-conformant** with OpenClaw plugin 
 - **Keywords added** (none existed before this release). 23 keywords covering the three pillars (cost / risk / audit), runtime authority, framework targeting (`openclaw`, `mcp`, `claude`, `anthropic`, `openai`), and brand.
 
 Driven by package-portfolio SEO diagnostic: this package shipped with zero npm `keywords`, which materially limited npm-search surfacing despite the highest unique-installer velocity in the org. Companion fixes for other client packages tracked in their respective repos.
+
+---
+
+## Publish Pipeline — npm Trusted Publishing (2026-07-21)
+
+**Files:** `.github/workflows/ci.yml`, `CHANGELOG.md`. **No plugin code changes.**
+
+**Issue:** The publish job authenticated with the long-lived org-level `NPM_TOKEN` secret. The same token expired and broke the `cycles-mcp-server` v0.3.0 release (npm reports an expired token on a scoped package as `E404` on PUT). Any repo publishing with that shared token has the same failure mode.
+
+**Fix:** The publish job now uses npm Trusted Publishing (OIDC): `NODE_AUTH_TOKEN` removed. The job already carried `id-token: write` and `npm install -g npm@latest` (OIDC requires npm >= 11.5.1; Node 20 bundles npm 10), so no other workflow changes were needed. `package.json` metadata was already normalized (`git+` repository URL) — `npm pkg fix` had no semantic changes. The trusted publisher for `@runcycles/openclaw-budget-guard` must be configured on npmjs.com (GitHub Actions: `runcycles/cycles-openclaw-budget-guard`, workflow `ci.yml`, no environment) before the next tagged release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ are in [`AUDIT.md`](AUDIT.md). This file is the summary index.
 
 ### Changed
 
+- npm publish now uses npm Trusted Publishing (OIDC) instead of the
+  long-lived `NPM_TOKEN` secret. The trusted publisher must be
+  configured for `@runcycles/openclaw-budget-guard` on npmjs.com
+  before the next tagged release. Mirrors the same change in
+  `cycles-mcp-server` (#143 there), whose v0.3.0 release initially
+  failed on an expired token.
 - `dev`: bump `typescript` 6.0.2 → 6.0.3, `vitest` 4.1.2 → 4.1.4,
   `@vitest/coverage-v8` 4.1.2 → 4.1.4, `@types/node` 25.5.0 → 25.6.0.
 


### PR DESCRIPTION
Same change as [cycles-mcp-server#143](https://github.com/runcycles/cycles-mcp-server/pull/143) and [cycles-client-typescript#160](https://github.com/runcycles/cycles-client-typescript/pull/160): the shared org-level `NPM_TOKEN` expired and broke the mcp-server v0.3.0 release; this repo publishes with the same token and had the same latent failure mode.

- Publish job: `NODE_AUTH_TOKEN` removed — the job already had `id-token: write` and upgrades npm to latest (OIDC needs npm >= 11.5.1), so no other workflow change.
- `package.json` metadata was already normalized (`git+` repo URL); `npm pkg fix` had no semantic changes.
- CHANGELOG + AUDIT.md updated. Tests: 380 passed.

⚠️ **Before the next tagged release:** configure the trusted publisher for `@runcycles/openclaw-budget-guard` on npmjs.com — GitHub Actions, repo `runcycles/cycles-openclaw-budget-guard`, workflow `ci.yml`, environment blank (or via `npm trust github @runcycles/openclaw-budget-guard --file ci.yml --repo runcycles/cycles-openclaw-budget-guard --allow-publish`).