### PR TITLE
docs: audit dependency maintenance

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -7,6 +7,14 @@
 
 ---
 
+## 2026-07-26 — workflow dependency maintenance
+
+Dependabot PRs #141 and #143 update the SHA-pinned checkout action to 7.0.1
+and the CodeQL SARIF uploader to 4.37.3. These are workflow-only patch updates:
+plugin code, configuration, package dependencies, OpenClaw hooks, and Cycles
+wire behavior are unchanged. Build, tests, typecheck, coverage, CodeQL, and
+the remaining repository checks passed on both reviewed heads.
+
 ## Summary
 
 | Category | Pass | Issues |


### PR DESCRIPTION
## Summary

- record Dependabot PRs #141 and #143 in `AUDIT.md`
- document their workflow-only scope and passing validation

## Why

The repository requires every maintenance change to have an audit record. This closes the documentation side of the reviewed dependency batch without changing plugin code or runtime behavior.

## Validation

- `git diff --check`
- all merged dependency PR checks passed
