### PR TITLE
feat: bump runcycles to ^0.4.0 and classify commit failures

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -3,9 +3,26 @@
 **Date:** 2026-07-18
 **Plugin:** `@runcycles/openclaw-budget-guard` v0.8.4 + unreleased fixes
 **Runtime:** OpenClaw >= 0.1.0, Node 20+
-**Cycles client:** `runcycles` ^0.3.0
+**Cycles client:** `runcycles` ^0.4.0
 
 ---
+
+## 2026-07-27 — runcycles ^0.4.0 and commit-failure classification
+
+Bumps `runcycles` from ^0.3.0 to ^0.4.0 (resolved 0.4.0: durable commit
+journal with replay, `POST /v1/events` fallback for expired commits, public
+`flushPendingCommits()`, and a streaming-commit contract change). The plugin
+calls `CyclesClient.commitReservation` directly and uses neither
+`reserveForStream` nor the lifecycle engine, so the SDK behavior change does
+not affect it and the journal does not engage. In the same change,
+`commitUsage` now classifies commit failures
+(transient/auth/expired/settled/rejected) mirroring the 0.4.0 lifecycle
+engine's `_handleCommit`, and `agent_end` no longer releases holds whose
+commit failed for a transient/auth/expired/settled reason — only genuine
+rejections and never-committed holds are released (fleet rule: never release
+spent budget). `src/cycles.ts:classifyCommitFailure`, `src/hooks.ts:agentEndFor`,
+`afterToolCallFor`, `src/types.ts:CommitFailureKind`. Typecheck and all 397
+tests pass; coverage 98.28% lines.
 
 ## 2026-07-26 — dependency and workflow maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ are in [`AUDIT.md`](AUDIT.md). This file is the summary index.
 
 ### Changed
 
+- Bumped `runcycles` from ^0.3.0 to ^0.4.0. The plugin uses the raw
+  `CyclesClient` (not the SDK's streaming/lifecycle engine), so the
+  0.4.0 durable-commit journal and streaming contract change do not
+  alter plugin behavior.
+- Commit failures are now classified (transient / auth / expired /
+  settled / rejected), mirroring the runcycles 0.4.0 lifecycle engine.
+  `agent_end` no longer releases a hold whose commit failed for a
+  transient, auth, expired, or settled reason — spent budget is never
+  released; only genuine rejections and never-committed holds are.
 - npm publish now uses npm Trusted Publishing (OIDC) instead of the
   long-lived `NPM_TOKEN` secret. The trusted publisher must be
   configured for `@runcycles/openclaw-budget-guard` on npmjs.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "runcycles": "^0.3.0"
+        "runcycles": "^0.4.0"
       },
       "devDependencies": {
         "@types/node": "^26.0.0",
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/runcycles": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/runcycles/-/runcycles-0.3.4.tgz",
-      "integrity": "sha512-alwPi/IEkE//bZKGydA2l0yuADlpetGEhGLZPz7JAczQuksiaNdck9bo3ZrNgiLPZWq7d1w1fnUr1Fq7ITt5QQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/runcycles/-/runcycles-0.4.0.tgz",
+      "integrity": "sha512-bbIltNerF4m1vbu4Dn5NYxIrLRG8pSwfU2kZwnb/0zFIlEGTTBgmE9M0P35rAljk+QeiFTpAIJexF1X4R7okew==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "runcycles": "^0.3.0"
+    "runcycles": "^0.4.0"
   },
   "overrides": {
     "esbuild": "^0.28.1"

--- a/src/cycles.ts
+++ b/src/cycles.ts
@@ -14,7 +14,14 @@ import {
   type ReservationCreateResponse,
 } from "runcycles";
 
-import type { BudgetGuardConfig, BudgetSnapshot, OpenClawLogger, StandardMetrics } from "./types.js";
+import type {
+  BudgetGuardConfig,
+  BudgetSnapshot,
+  CommitFailureKind,
+  CommitFailureSink,
+  OpenClawLogger,
+  StandardMetrics,
+} from "./types.js";
 import { classifyBudget } from "./budget.js";
 
 function sleepMs(ms: number): Promise<void> {
@@ -244,6 +251,25 @@ export async function reserveBudget(
 // Commit (best-effort — never throws, but reports the outcome)
 // ---------------------------------------------------------------------------
 
+/**
+ * Classify a failed commit response, mirroring runcycles 0.4.0
+ * `src/lifecycle.ts` `_handleCommit`. Only `"rejected"` (genuine 4xx with a
+ * classifiable error) should ever lead to a release of the hold.
+ */
+function classifyCommitFailure(
+  status: number | undefined,
+  errorCode: string | undefined,
+): CommitFailureKind {
+  if (status === 410 || errorCode === "RESERVATION_EXPIRED") return "expired";
+  if (errorCode === "RESERVATION_FINALIZED" || errorCode === "IDEMPOTENCY_MISMATCH") {
+    return "settled";
+  }
+  if (status === 401 || status === 403) return "auth";
+  if (status === 429 || errorCode === "LIMIT_EXCEEDED") return "transient";
+  if (status !== undefined && status >= 400 && status < 500) return "rejected";
+  return "transient"; // 5xx, transport errors, unclassifiable
+}
+
 export async function commitUsage(
   client: CyclesClient,
   reservationId: string,
@@ -251,6 +277,7 @@ export async function commitUsage(
   unit: string,
   logger: OpenClawLogger,
   metrics?: StandardMetrics,
+  failure?: CommitFailureSink,
 ): Promise<boolean> {
   try {
     const body: Record<string, unknown> = {
@@ -262,13 +289,20 @@ export async function commitUsage(
     }
     const response = await client.commitReservation(reservationId, body);
     if (!response.isSuccess) {
+      const rawError = response.body?.error;
+      const kind = classifyCommitFailure(
+        response.status,
+        typeof rawError === "string" ? rawError : undefined,
+      );
+      if (failure) failure.kind = kind;
       logger.warn(
-        `Commit for reservation ${reservationId} returned status ${response.status}`,
+        `Commit for reservation ${reservationId} returned status ${response.status} (${kind})`,
       );
       return false;
     }
     return true;
   } catch (err) {
+    if (failure) failure.kind = "transient";
     logger.warn(`Commit failed for reservation ${reservationId}:`, err);
     return false;
   }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,6 +15,7 @@ import type {
   BudgetGuardConfig,
   BudgetLevel,
   BudgetSnapshot,
+  CommitFailureSink,
   HookContext,
   MetricsEmitter,
   ModelResolveEvent,
@@ -608,6 +609,7 @@ function stopAllHeartbeats(state: SessionState): void {
 async function commitPendingModelReservationFor(
   runtime: HookRuntime,
   state: SessionState,
+  failure?: CommitFailureSink,
 ): Promise<PendingModelCommitOutcome> {
   const { client, config, logger } = runtime;
   const emitCounter = (name: string, delta: number, tags?: Record<string, string>) =>
@@ -644,6 +646,7 @@ async function commitPendingModelReservationFor(
     unit,
     logger,
     metrics,
+    failure,
   );
   if (committed === false) {
     logger.warn(
@@ -1196,14 +1199,18 @@ async function afterToolCallFor(
   }
 
   const unit = reservation.currency ?? config.currency;
+  const failure: CommitFailureSink = {};
   const committed = await commitUsage(
     client,
     reservation.reservationId,
     actual,
     unit,
     logger,
+    undefined,
+    failure,
   );
   if (committed === false) {
+    reservation.commitFailureKind = failure.kind;
     logger.warn(
       `Tool commit failed for ${reservation.toolName}; retaining reservation for agent_end cleanup`,
     );
@@ -1255,12 +1262,22 @@ async function agentEndFor(
     if (state.pendingModelReservation) {
       const resId = state.pendingModelReservation.reservationId;
       try {
-        const outcome = await commitPendingModelReservationFor(runtime, state);
+        const failure: CommitFailureSink = {};
+        const outcome = await commitPendingModelReservationFor(runtime, state, failure);
         if (outcome === "deferred") {
-          logger.warn(
-            `Failed to commit pending model reservation ${resId} at agent_end, releasing`,
-          );
-          await releaseReservation(client, resId, "commit_failed_at_agent_end", logger);
+          // Fleet rule (runcycles 0.4.0 lifecycle): never release spent budget
+          // on transient/auth/expired/settled commit failures — only a genuine
+          // rejection means the hold should be freed.
+          if (failure.kind !== undefined && failure.kind !== "rejected") {
+            logger.warn(
+              `Pending model commit for ${resId} failed as ${failure.kind} at agent_end — retaining hold (spend is real; server TTL governs)`,
+            );
+          } else {
+            logger.warn(
+              `Failed to commit pending model reservation ${resId} at agent_end, releasing`,
+            );
+            await releaseReservation(client, resId, "commit_failed_at_agent_end", logger);
+          }
         }
       } catch (err) {
         logger.warn(`Unexpected error committing pending model reservation ${resId} at agent_end, releasing:`, err);
@@ -1272,18 +1289,33 @@ async function agentEndFor(
     stopAllHeartbeats(state);
 
     // Release any orphaned reservations belonging to this session only.
+    // Fleet rule (runcycles 0.4.0 lifecycle): holds whose commit failed for a
+    // transient/auth/expired/settled reason represent spent budget and are
+    // retained (server TTL governs); only never-committed holds and genuine
+    // commit rejections are released.
     if (state.activeReservations.size > 0) {
-      logger.warn(
-        `agent_end: releasing ${state.activeReservations.size} orphaned reservation(s)`,
+      const all = [...state.activeReservations.values()];
+      const retained = all.filter(
+        (r) => r.commitFailureKind !== undefined && r.commitFailureKind !== "rejected",
       );
-      const orphaned = [...state.activeReservations.values()];
-      for (const r of orphaned) {
-        logEvent(state, { timestamp: Date.now(), hook: "agent_end", action: "release", kind: r.kind, name: r.toolName, amount: r.estimate, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
+      const orphaned = all.filter((r) => !retained.includes(r));
+      for (const r of retained) {
+        logger.warn(
+          `agent_end: retaining reservation ${r.reservationId} (${r.toolName}) — commit failed as ${r.commitFailureKind}; not releasing spent budget`,
+        );
       }
-      const releases = orphaned.map((r) =>
-        releaseReservation(client, r.reservationId, "agent_end_cleanup", logger),
-      );
-      await Promise.allSettled(releases);
+      if (orphaned.length > 0) {
+        logger.warn(
+          `agent_end: releasing ${orphaned.length} orphaned reservation(s)`,
+        );
+        for (const r of orphaned) {
+          logEvent(state, { timestamp: Date.now(), hook: "agent_end", action: "release", kind: r.kind, name: r.toolName, amount: r.estimate, budgetLevel: state.cachedSnapshot?.level ?? "healthy", remaining: state.cachedSnapshot?.remaining ?? 0 });
+        }
+        const releases = orphaned.map((r) =>
+          releaseReservation(client, r.reservationId, "agent_end_cleanup", logger),
+        );
+        await Promise.allSettled(releases);
+      }
       state.activeReservations.clear();
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,26 @@ export interface ActiveReservation {
   createdAt: number;
   kind: "model" | "tool";
   currency?: string;
+  /** Set when a commit attempt failed; drives release-vs-retain at agent_end. */
+  commitFailureKind?: CommitFailureKind;
+}
+
+/**
+ * Classification of a failed commit attempt, mirroring the runcycles 0.4.0
+ * lifecycle engine (`_handleCommit`): only a genuine rejection warrants
+ * releasing the hold — transient/auth/expired/settled failures represent
+ * spent budget and must never be released (fleet rule).
+ */
+export type CommitFailureKind =
+  | "transient" // transport error, 5xx, 429/LIMIT_EXCEEDED, unclassifiable
+  | "auth" // 401/403 — credentials issue, spend still real
+  | "expired" // 410/RESERVATION_EXPIRED — server already returned the hold
+  | "settled" // RESERVATION_FINALIZED/IDEMPOTENCY_MISMATCH — already finalized
+  | "rejected"; // genuine 4xx rejection — releasing the hold is correct
+
+/** Optional out-parameter for {@link commitUsage} failure classification. */
+export interface CommitFailureSink {
+  kind?: CommitFailureKind;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/cycles.test.ts
+++ b/tests/cycles.test.ts
@@ -909,6 +909,70 @@ describe("commitUsage", () => {
     const callBody = mockCommitReservation.mock.calls[0][1] as Record<string, unknown>;
     expect(callBody).not.toHaveProperty("metrics");
   });
+
+  describe("failure classification (mirrors runcycles 0.4.0 _handleCommit)", () => {
+    const classify = async (response: Record<string, unknown>) => {
+      mockCommitReservation.mockResolvedValue({ isSuccess: false, ...response });
+      const failure: { kind?: string } = {};
+      const client = createCyclesClient(makeConfig());
+      const committed = await commitUsage(
+        client, "res-c", 500_000, "USD_MICROCENTS", logger, undefined, failure,
+      );
+      expect(committed).toBe(false);
+      return failure.kind;
+    };
+
+    it("classifies 5xx as transient", async () => {
+      expect(await classify({ status: 503 })).toBe("transient");
+    });
+
+    it("classifies 429 as transient", async () => {
+      expect(await classify({ status: 429 })).toBe("transient");
+    });
+
+    it("classifies LIMIT_EXCEEDED as transient", async () => {
+      expect(await classify({ status: 400, body: { error: "LIMIT_EXCEEDED" } })).toBe("transient");
+    });
+
+    it("classifies 401 and 403 as auth", async () => {
+      expect(await classify({ status: 401 })).toBe("auth");
+      expect(await classify({ status: 403 })).toBe("auth");
+    });
+
+    it("classifies 410 / RESERVATION_EXPIRED as expired", async () => {
+      expect(await classify({ status: 410 })).toBe("expired");
+      expect(await classify({ status: 409, body: { error: "RESERVATION_EXPIRED" } })).toBe("expired");
+    });
+
+    it("classifies RESERVATION_FINALIZED / IDEMPOTENCY_MISMATCH as settled", async () => {
+      expect(await classify({ status: 409, body: { error: "RESERVATION_FINALIZED" } })).toBe("settled");
+      expect(await classify({ status: 409, body: { error: "IDEMPOTENCY_MISMATCH" } })).toBe("settled");
+    });
+
+    it("classifies other 4xx as rejected", async () => {
+      expect(await classify({ status: 422, body: { error: "INVALID_AMOUNT" } })).toBe("rejected");
+      expect(await classify({ status: 404 })).toBe("rejected");
+    });
+
+    it("classifies a thrown transport error as transient", async () => {
+      mockCommitReservation.mockRejectedValue(new Error("network fail"));
+      const failure: { kind?: string } = {};
+      const client = createCyclesClient(makeConfig());
+      const committed = await commitUsage(
+        client, "res-c", 500_000, "USD_MICROCENTS", logger, undefined, failure,
+      );
+      expect(committed).toBe(false);
+      expect(failure.kind).toBe("transient");
+    });
+
+    it("does not require a failure sink", async () => {
+      mockCommitReservation.mockResolvedValue({ isSuccess: false, status: 503 });
+      const client = createCyclesClient(makeConfig());
+      await expect(
+        commitUsage(client, "res-c", 500_000, "USD_MICROCENTS", logger),
+      ).resolves.toBe(false);
+    });
+  });
 });
 
 describe("releaseReservation", () => {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -297,6 +297,7 @@ describe("beforeModelResolve", () => {
       expect.any(String),
       expect.anything(),
       expect.objectContaining({ model_version: "gpt-4o" }),
+      undefined,
     );
   });
 
@@ -1261,6 +1262,8 @@ describe("afterToolCall", () => {
       expect.any(Number),
       "USD_MICROCENTS",
       expect.anything(),
+      undefined,
+      expect.anything(),
     );
   });
 
@@ -1338,6 +1341,8 @@ describe("afterToolCall", () => {
       42_000,
       expect.any(String),
       expect.anything(),
+      undefined,
+      expect.anything(),
     );
   });
 
@@ -1372,6 +1377,8 @@ describe("afterToolCall", () => {
       200_000,
       expect.any(String),
       expect.anything(),
+      undefined,
+      expect.anything(),
     );
   });
 
@@ -1402,6 +1409,8 @@ describe("afterToolCall", () => {
       200_000,
       expect.any(String),
       expect.anything(),
+      undefined,
+      expect.anything(),
     );
   });
 
@@ -1431,6 +1440,8 @@ describe("afterToolCall", () => {
       "res-no-currency",
       expect.any(Number),
       "CREDITS",
+      expect.anything(),
+      undefined,
       expect.anything(),
     );
   });
@@ -2024,6 +2035,7 @@ describe("v0.5.0 — model reserve-then-commit", () => {
       expect.any(String),
       expect.anything(),
       expect.objectContaining({ model_version: "gpt-4o" }),
+      expect.anything(),
     );
   });
 
@@ -2047,6 +2059,7 @@ describe("v0.5.0 — model reserve-then-commit", () => {
       expect.any(String),
       expect.anything(),
       expect.objectContaining({ model_version: "gpt-4o" }),
+      undefined,
     );
   });
 
@@ -2067,6 +2080,7 @@ describe("v0.5.0 — model reserve-then-commit", () => {
       expect.any(String),
       expect.anything(),
       expect.anything(),
+      undefined,
     );
   });
 
@@ -2091,6 +2105,7 @@ describe("v0.5.0 — model reserve-then-commit", () => {
       expect.any(String),
       expect.anything(),
       expect.anything(),
+      undefined,
     );
   });
 
@@ -2114,6 +2129,7 @@ describe("v0.5.0 — model reserve-then-commit", () => {
       expect.any(String),
       expect.anything(),
       expect.anything(),
+      undefined,
     );
   });
 
@@ -2134,6 +2150,7 @@ describe("v0.5.0 — model reserve-then-commit", () => {
       "TOKENS",
       expect.anything(),
       expect.anything(),
+      undefined,
     );
   });
 
@@ -2478,6 +2495,8 @@ describe("v0.5.0 — cost breakdown accumulates for repeated tools", () => {
       "tc",
       200_000,
       "TOKENS",
+      expect.anything(),
+      undefined,
       expect.anything(),
     );
   });
@@ -3376,6 +3395,108 @@ describe("v0.7.10 — model reservation release on commit failure", () => {
   });
 });
 
+describe("commit-failure classification — never release spent budget (runcycles 0.4.0 fleet rule)", () => {
+  const failCommitAs = (kind: string) => {
+    mockCommitUsage.mockImplementation((...args: unknown[]) => {
+      const sink = args[6] as { kind?: string } | undefined;
+      if (sink) sink.kind = kind;
+      return Promise.resolve(false);
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReleaseReservation.mockResolvedValue(undefined);
+    mockFetchBudgetState.mockResolvedValue(makeSnapshot({ level: "healthy" }));
+    mockIsAllowed.mockReturnValue(true);
+    mockIsToolPermitted.mockReturnValue({ permitted: true });
+  });
+
+  it.each(["transient", "auth", "expired", "settled"])(
+    "retains the pending model hold at agentEnd when the commit failure is %s",
+    async (kind) => {
+      setup();
+      mockReserveBudget.mockResolvedValue({ decision: "ALLOW", reservationId: "model-r1", affectedScopes: [] });
+      failCommitAs(kind);
+
+      await beforeModelResolve({ model: "gpt-4o" }, makeHookContext());
+      await agentEnd({}, makeHookContext());
+
+      expect(mockReleaseReservation).not.toHaveBeenCalled();
+    },
+  );
+
+  it("releases the pending model hold at agentEnd when the commit is genuinely rejected", async () => {
+    setup();
+    mockReserveBudget.mockResolvedValue({ decision: "ALLOW", reservationId: "model-r1", affectedScopes: [] });
+    failCommitAs("rejected");
+
+    await beforeModelResolve({ model: "gpt-4o" }, makeHookContext());
+    await agentEnd({}, makeHookContext());
+
+    expect(mockReleaseReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      "model-r1",
+      "commit_failed_at_agent_end",
+      expect.anything(),
+    );
+  });
+
+  it("retains a tool hold at agentEnd when its commit failed transiently", async () => {
+    setup({ heartbeatIntervalMs: 0, toolBaseCosts: { tool: 100 } });
+    const ctx = makeHookContext();
+    mockReserveBudget.mockResolvedValue({ decision: "ALLOW", reservationId: "tool-r1", affectedScopes: [] });
+
+    await beforeToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    failCommitAs("transient");
+    await afterToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    await agentEnd({}, ctx);
+
+    expect(mockReleaseReservation).not.toHaveBeenCalled();
+  });
+
+  it("releases a tool hold at agentEnd when its commit was genuinely rejected", async () => {
+    setup({ heartbeatIntervalMs: 0, toolBaseCosts: { tool: 100 } });
+    const ctx = makeHookContext();
+    mockReserveBudget.mockResolvedValue({ decision: "ALLOW", reservationId: "tool-r1", affectedScopes: [] });
+
+    await beforeToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    failCommitAs("rejected");
+    await afterToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    await agentEnd({}, ctx);
+
+    expect(mockReleaseReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      "tool-r1",
+      "agent_end_cleanup",
+      expect.anything(),
+    );
+  });
+
+  it("still releases never-committed tool holds at agentEnd alongside a retained one", async () => {
+    setup({ heartbeatIntervalMs: 0, toolBaseCosts: { tool: 100 } });
+    const ctx = makeHookContext();
+    mockReserveBudget
+      .mockResolvedValueOnce({ decision: "ALLOW", reservationId: "tool-r1", affectedScopes: [] })
+      .mockResolvedValueOnce({ decision: "ALLOW", reservationId: "tool-r2", affectedScopes: [] });
+
+    await beforeToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    await beforeToolCall({ toolName: "tool", toolCallId: "call-2" }, ctx);
+    failCommitAs("transient");
+    // call-1 commit fails transiently → retained; call-2 never commits → orphaned
+    await afterToolCall({ toolName: "tool", toolCallId: "call-1" }, ctx);
+    await agentEnd({}, ctx);
+
+    expect(mockReleaseReservation).toHaveBeenCalledTimes(1);
+    expect(mockReleaseReservation).toHaveBeenCalledWith(
+      expect.anything(),
+      "tool-r2",
+      "agent_end_cleanup",
+      expect.anything(),
+    );
+  });
+});
+
 describe("terminal session state cleanup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -3460,6 +3581,8 @@ describe("v0.7.10 — costEstimator null handling", () => {
       "r1",
       200_000,
       expect.any(String),
+      expect.anything(),
+      undefined,
       expect.anything(),
     );
   });


### PR DESCRIPTION
## Summary

Bumps `runcycles` from `^0.3.0` to `^0.4.0` (resolved 0.4.0, verified live on npm) and adopts the 0.4.0 lifecycle engine's commit-failure taxonomy in the plugin's own deferred-commit orchestration.

runcycles 0.4.0 ships durable commit retries: an on-disk journal with replay, a `POST /v1/events` fallback for expired commits, a public `flushPendingCommits()` for serverless, and a behavior change to `StreamReservation.commit()` — it now resolves on transient failures (journaled) and throws only on genuine rejections (runcycles/cycles-client-typescript#172).

## Impact on this plugin

- Verified by grep: the plugin uses **only** the raw `CyclesClient.commitReservation` (via `commitUsage` in `src/cycles.ts`) — no `reserveForStream`, no `withCycles`. The raw client methods are unchanged in 0.4.0, so the SDK behavior change does not affect the plugin, and the SDK journal never engages. Since the SDK engine is unused, there is no hook where `flushPendingCommits()` applies (revisit if the plugin ever adopts the engine).
- The plugin's own release-on-commit-failure logic did, however, violate the fleet rule "never release spent budget on transient/auth/expired failures" — fixed here.

## Behavior change: commit-failure classification

Mirrors runcycles 0.4.0 `src/lifecycle.ts` `_handleCommit`:

- `commitUsage` (`src/cycles.ts`) now classifies failures via an optional out-parameter: **transient** (transport, 5xx, 429/`LIMIT_EXCEEDED`, unclassifiable), **auth** (401/403), **expired** (410/`RESERVATION_EXPIRED`), **settled** (`RESERVATION_FINALIZED`/`IDEMPOTENCY_MISMATCH`), **rejected** (other classifiable 4xx). Return contract (`Promise<boolean>`) is unchanged.
- `agent_end` pending-model cleanup (`src/hooks.ts`) releases the hold only on a genuine **rejected** failure; transient/auth/expired/settled failures retain the hold (spend is real; server TTL governs).
- `agent_end` orphan cleanup likewise retains tool holds whose commit failed non-rejected (kind recorded on the `ActiveReservation`), while still releasing never-committed orphans and genuine rejections.

Fail-open semantics, per-turn deferred-commit handling, and all existing call sites are otherwise unchanged.

## Test results

- `npm run typecheck`: clean
- `npx vitest run --coverage`: **397 passed** (17 new: 9 classification tests in `tests/cycles.test.ts`, 8 retain-vs-release lifecycle tests in `tests/hooks.test.ts`), coverage **98.28% lines / 95.82% branches** (>= 95% gate)

## Docs

- `AUDIT.md`: dated 2026-07-27 entry; client header updated to `^0.4.0`.
- `CHANGELOG.md`: `[Unreleased]` Changed entries for the bump and the release-vs-retain change.
